### PR TITLE
Revert "feat(docker-image): update talos group to v1.8.0 (minor)"

### DIFF
--- a/.taskfiles/talos.yml
+++ b/.taskfiles/talos.yml
@@ -6,7 +6,7 @@ vars:
   NODE:
     sh: "echo ${NODE:-192.168.48.{{ add .N 1 }}}"
   # renovate: datasource=github-releases depName=mmalyska/talos-images
-  TALOS_VERSION: "v1.8.0"
+  TALOS_VERSION: "v1.7.6"
   # renovate: datasource=github-releases depName=siderolabs/kubelet
   KUBERNETES_VERSION: "v1.30.5"
   # renovate: datasource=github-releases depName=budimanjojo/talhelper

--- a/provision/talos/talconfig.yaml
+++ b/provision/talos/talconfig.yaml
@@ -1,6 +1,6 @@
 clusterName: home
 # renovate: datasource=github-releases depName=mmalyska/talos-images
-talosVersion: v1.8.0
+talosVersion: v1.7.6
 # renovate: datasource=github-releases depName=siderolabs/kubelet
 kubernetesVersion: v1.30.5
 endpoint: https://${clusterDomain}:6443
@@ -93,7 +93,7 @@ controlPlane:
           fs.inotify.max_user_instances: "8192"
         install:
           # renovate-docker
-          image: ghcr.io/mmalyska/talos-installer:v1.8.0@sha256:22957461eaa196a32b9adafa2d83e7d96bd5b6ef1f3d25018cd620bee786d820
+          image: ghcr.io/mmalyska/talos-installer:v1.7.6@sha256:8583409272d3780fe902e3dd9bae944753767d9c73cf0d05e315a0f56ffb00ee
           extraKernelArgs:
             - net.ifnames=0
         features:


### PR DESCRIPTION
Reverts mmalyska/home-ops#1835
I'm doing revert as ARP advertisements are not working for metallb in 1.8.0 so my external IPs are not accessible outside cluster