### PR TITLE
feat(wow): add AzerothCore WotLK single-player server

### DIFF
--- a/cluster/apps/games/wow/Chart.yaml
+++ b/cluster/apps/games/wow/Chart.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v2
+name: wow
+description: AzerothCore WotLK single-player server
+type: application
+version: 1.0.0
+appVersion: 1.0.0
+dependencies:
+  - name: common
+    version: 5.0.0
+    repository: https://bjw-s-labs.github.io/helm-charts

--- a/cluster/apps/games/wow/README.md
+++ b/cluster/apps/games/wow/README.md
@@ -1,0 +1,113 @@
+# WoW WotLK AzerothCore — Single Player
+
+AzerothCore 3.3.5a private server with mods:
+- **mod-solocraft** — dungeon difficulty scaling for solo play
+- **mod-ah-bot** — auction house bot (buyer + seller)
+- **mod-individual-progression** — per-player progression stages
+
+## Client Setup
+
+1. WoW version required: **3.3.5a (build 12340)**
+2. Edit `Data/enUS/realmlist.wtf`:
+   ```
+   set realmlist wow.mmalyska.cloud
+   ```
+   Or use `192.168.48.29` directly.
+3. External access: connect to home router VPN first, then launch WoW.
+
+## First-Time Setup (after ArgoCD sync)
+
+After the first sync, the db-import PostSync job runs automatically. Once it completes, worldserver and authserver will be healthy. Then run these steps:
+
+**1. Fix realmlist entry** (so clients connect to the correct IP):
+```bash
+kubectl exec -n wow statefulset/mysql -- mysql -u root -p$MYSQL_ROOT_PASSWORD acore_auth \
+  -e "UPDATE realmlist SET address='192.168.48.29' WHERE id=1;"
+```
+
+**2. Create admin account** (via worldserver stdin — the worldserver accepts commands):
+```bash
+kubectl exec -n wow deploy/wow-worldserver -it -- bash
+# The worldserver console is active; type commands directly:
+account create admin <password>
+account set gmlevel admin 3 -1
+```
+
+**3. Set up AHBot** (requires an in-game character):
+1. Create the ahbot account: `account create ahbot ahbot`
+2. Log in as `ahbot`, create a character named `Auctioneer`, enter the world once, then log out.
+3. Get the character GUID:
+   ```bash
+   kubectl exec -n wow statefulset/mysql -- mysql -u root -p$MYSQL_ROOT_PASSWORD \
+     -e "SELECT guid FROM acore_characters.characters WHERE name='Auctioneer';"
+   ```
+4. Edit `mod_ahbot.conf` (inside worldserver pod at `/azerothcore/env/dist/etc/modules/`):
+   ```
+   AuctionHouseBot.Account = <account_id>
+   AuctionHouseBot.Guid = <character_guid>
+   ```
+5. Restart worldserver: `kubectl rollout restart -n wow deploy/wow-worldserver`
+
+## Day-to-Day Operations
+
+| Task | Command |
+|------|---------|
+| Stop worldserver | `kubectl scale -n wow deploy/wow-worldserver --replicas=0` |
+| Start worldserver | `kubectl scale -n wow deploy/wow-worldserver --replicas=1` |
+| Worldserver console | `kubectl exec -n wow deploy/wow-worldserver -it -- bash` |
+| DB admin UI | `https://wow-adminer.mmalyska.cloud` (internal network only) |
+| View worldserver logs | `kubectl logs -n wow deploy/wow-worldserver -f` |
+
+## Module Configuration
+
+Config files are at `/azerothcore/env/dist/etc/modules/` inside the worldserver pod. Edit then restart.
+
+- **mod-solocraft** (`mod_solocraft.conf`) — `SoloCraft.Enable`, difficulty multipliers per dungeon size
+- **mod-ah-bot** (`mod_ahbot.conf`) — enable buyer/seller, item quotas by rarity, AHBot account/GUID
+- **mod-individual-progression** (`mod_individual_progression.conf`) — progression stage settings
+
+After editing configs, restart: `kubectl rollout restart -n wow deploy/wow-worldserver`
+
+## Updates
+
+1. Update the Dockerfile in `mmalyska/containers` (bump module clone SHAs or base image tag)
+2. Rebuild images — CI publishes new digests to `ghcr.io/mmalyska/`
+3. Update `tag:` + `sha256:` in `values.yaml` for the affected image(s)
+4. Commit + merge → ArgoCD syncs automatically
+
+## Backup
+
+Volsync backs up the MySQL PVC (`wow-mysql`) every 12h to Restic (S3).
+
+```bash
+# Check backup status
+kubectl get replicationsource -n wow
+
+# Trigger immediate backup
+kubectl annotate replicationsource -n wow wow-mysql volsync.backube/trigger-immediate=true
+```
+
+## Disaster Recovery
+
+**Full rebuild:**
+1. Bitwarden secrets already exist — ExternalSecret restores `wow-mysql-secret` and `wow-restic-secret` automatically
+2. Sync ArgoCD app — MySQL PVC is new/empty, worldserver client-data re-downloads on pod start
+3. Restore MySQL from Restic:
+   ```yaml
+   apiVersion: volsync.backube/v1alpha1
+   kind: ReplicationDestination
+   metadata:
+     name: wow-mysql-restore
+     namespace: wow
+   spec:
+     trigger:
+       manual: restore-once
+     restic:
+       copyMethod: Snapshot
+       destinationPVC: wow-mysql
+       repository: wow-restic-secret
+       accessModes: [ReadWriteOnce]
+       storageClassName: ceph-block
+       capacity: 10Gi
+   ```
+4. Once restore completes, delete the `ReplicationDestination` and sync ArgoCD to start services.

--- a/cluster/apps/games/wow/app-config.yaml
+++ b/cluster/apps/games/wow/app-config.yaml
@@ -1,0 +1,10 @@
+- enabled: "true"
+  namespace: wow
+  syncPolicy:
+    enabled: true
+    selfHeal: true
+    prune: false
+  plugin:
+    env:
+      - name: SECRET_PROVIDER
+        value: cluster-secrets

--- a/cluster/apps/games/wow/templates/adminer-httproute.yaml
+++ b/cluster/apps/games/wow/templates/adminer-httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: wow-adminer
+  namespace: wow
+  annotations:
+    external-dns.alpha.kubernetes.io/controller: dns-controller
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: envoy-gateway
+      sectionName: https
+  hostnames:
+    - wow-adminer.<secret:private-domain>
+  rules:
+    - backendRefs:
+        - name: wow-adminer
+          port: 8080

--- a/cluster/apps/games/wow/templates/client-data-pvc.yaml
+++ b/cluster/apps/games/wow/templates/client-data-pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wow-client-data
+  namespace: wow
+spec:
+  storageClassName: ceph-block
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 40Gi

--- a/cluster/apps/games/wow/templates/common.yaml
+++ b/cluster/apps/games/wow/templates/common.yaml
@@ -1,0 +1,12 @@
+{{- include "bjw-s.common.loader.init" . }}
+
+{{- define "wow.hardcodedValues" -}}
+{{ if not .Values.global.nameOverride }}
+global:
+    nameOverride: "{{ .Release.Name }}"
+{{ end }}
+{{- end -}}
+{{- $_ := mergeOverwrite .Values (include "wow.hardcodedValues" . | fromYaml) -}}
+
+{{/* Render the templates */}}
+{{ include "bjw-s.common.loader.generate" . }}

--- a/cluster/apps/games/wow/templates/db-import-job.yaml
+++ b/cluster/apps/games/wow/templates/db-import-job.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wow-db-import
+  namespace: wow
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 5
+  template:
+    spec:
+      restartPolicy: OnFailure
+      initContainers:
+        - name: wait-for-mysql
+          image: mysql:8.4
+          command:
+            - sh
+            - -c
+            - |
+              until mysqladmin ping -h mysql -u root -p$MYSQL_ROOT_PASSWORD --silent; do
+                echo "waiting for mysql..."; sleep 5
+              done
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wow-mysql-secret
+                  key: MYSQL_ROOT_PASSWORD
+      containers:
+        - name: db-import
+          image: ghcr.io/mmalyska/azerothcore-db-import:stable@sha256:replaceme
+          env:
+            - name: AC_DATA_DIR
+              value: /azerothcore/env/dist/data
+            - name: AC_LOGS_DIR
+              value: /azerothcore/env/dist/logs
+            - name: AC_LOGIN_DATABASE_INFO
+              valueFrom:
+                secretKeyRef:
+                  name: wow-mysql-secret
+                  key: AC_LOGIN_DATABASE_INFO_ROOT
+            - name: AC_WORLD_DATABASE_INFO
+              valueFrom:
+                secretKeyRef:
+                  name: wow-mysql-secret
+                  key: AC_WORLD_DATABASE_INFO_ROOT
+            - name: AC_CHARACTER_DATABASE_INFO
+              valueFrom:
+                secretKeyRef:
+                  name: wow-mysql-secret
+                  key: AC_CHARACTER_DATABASE_INFO_ROOT

--- a/cluster/apps/games/wow/templates/db-import-job.yaml
+++ b/cluster/apps/games/wow/templates/db-import-job.yaml
@@ -5,8 +5,9 @@ metadata:
   name: wow-db-import
   namespace: wow
   annotations:
-    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "3"
 spec:
   backoffLimit: 5
   template:

--- a/cluster/apps/games/wow/templates/db-import-job.yaml
+++ b/cluster/apps/games/wow/templates/db-import-job.yaml
@@ -30,7 +30,7 @@ spec:
                   key: MYSQL_ROOT_PASSWORD
       containers:
         - name: db-import
-          image: ghcr.io/mmalyska/azerothcore-db-import:stable@sha256:replaceme
+          image: ghcr.io/mmalyska/azerothcore-db-import:2026-05-10@sha256:8a0ce28753b59874b988f91033ff659909432734ab876e00be6cce86c7215065
           env:
             - name: AC_DATA_DIR
               value: /azerothcore/env/dist/data

--- a/cluster/apps/games/wow/templates/db-import-job.yaml
+++ b/cluster/apps/games/wow/templates/db-import-job.yaml
@@ -30,7 +30,7 @@ spec:
                   key: MYSQL_ROOT_PASSWORD
       containers:
         - name: db-import
-          image: ghcr.io/mmalyska/azerothcore-db-import:2026-05-10@sha256:8a0ce28753b59874b988f91033ff659909432734ab876e00be6cce86c7215065
+          image: ghcr.io/mmalyska/azerothcore-db-import:rolling@sha256:8a0ce28753b59874b988f91033ff659909432734ab876e00be6cce86c7215065
           env:
             - name: AC_DATA_DIR
               value: /azerothcore/env/dist/data

--- a/cluster/apps/games/wow/templates/dns-endpoint.yaml
+++ b/cluster/apps/games/wow/templates/dns-endpoint.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: wow-game
+  namespace: wow
+  annotations:
+    external-dns.alpha.kubernetes.io/controller: internal
+spec:
+  endpoints:
+    - dnsName: wow.<secret:private-domain>
+      recordType: A
+      targets:
+        - "192.168.48.29"

--- a/cluster/apps/games/wow/templates/mysql-externalsecret.yaml
+++ b/cluster/apps/games/wow/templates/mysql-externalsecret.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: wow-mysql
+  namespace: wow
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  refreshInterval: 1h
+  target:
+    name: wow-mysql-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        MYSQL_ROOT_PASSWORD: '{{`{{ .MYSQL_ROOT_PASSWORD }}`}}'
+        MYSQL_PASSWORD: '{{`{{ .MYSQL_PASSWORD }}`}}'
+        AC_LOGIN_DATABASE_INFO: 'mysql;3306;acore;{{`{{ .MYSQL_PASSWORD }}`}};acore_auth'
+        AC_WORLD_DATABASE_INFO: 'mysql;3306;acore;{{`{{ .MYSQL_PASSWORD }}`}};acore_world'
+        AC_CHARACTER_DATABASE_INFO: 'mysql;3306;acore;{{`{{ .MYSQL_PASSWORD }}`}};acore_characters'
+        AC_LOGIN_DATABASE_INFO_ROOT: 'mysql;3306;root;{{`{{ .MYSQL_ROOT_PASSWORD }}`}};acore_auth'
+        AC_WORLD_DATABASE_INFO_ROOT: 'mysql;3306;root;{{`{{ .MYSQL_ROOT_PASSWORD }}`}};acore_world'
+        AC_CHARACTER_DATABASE_INFO_ROOT: 'mysql;3306;root;{{`{{ .MYSQL_ROOT_PASSWORD }}`}};acore_characters'
+  data:
+    - secretKey: MYSQL_ROOT_PASSWORD
+      remoteRef:
+        key: "7471542b-ab56-424c-b617-b446012f1c3f" #gitleaks:allow #WOW_MYSQL_ROOT_PASSWORD
+    - secretKey: MYSQL_PASSWORD
+      remoteRef:
+        key: "208505b7-149e-4b70-9e12-b446012f5258" #gitleaks:allow #WOW_MYSQL_ACORE_PASSWORD

--- a/cluster/apps/games/wow/templates/mysql-externalsecret.yaml
+++ b/cluster/apps/games/wow/templates/mysql-externalsecret.yaml
@@ -4,6 +4,8 @@ kind: ExternalSecret
 metadata:
   name: wow-mysql
   namespace: wow
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   secretStoreRef:
     kind: ClusterSecretStore

--- a/cluster/apps/games/wow/templates/mysql-pvc.yaml
+++ b/cluster/apps/games/wow/templates/mysql-pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wow-mysql
+  namespace: wow
+spec:
+  storageClassName: ceph-block
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/cluster/apps/games/wow/templates/mysql-service.yaml
+++ b/cluster/apps/games/wow/templates/mysql-service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: wow
+spec:
+  selector:
+    app: mysql
+  ports:
+    - name: mysql
+      port: 3306
+      targetPort: mysql

--- a/cluster/apps/games/wow/templates/mysql-statefulset.yaml
+++ b/cluster/apps/games/wow/templates/mysql-statefulset.yaml
@@ -17,6 +17,8 @@ kind: StatefulSet
 metadata:
   name: mysql
   namespace: wow
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   selector:
     matchLabels:

--- a/cluster/apps/games/wow/templates/mysql-statefulset.yaml
+++ b/cluster/apps/games/wow/templates/mysql-statefulset.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql-initdb
+  namespace: wow
+data:
+  init.sql: |
+    CREATE DATABASE IF NOT EXISTS `acore_world`;
+    CREATE DATABASE IF NOT EXISTS `acore_characters`;
+    GRANT ALL ON `acore_world`.* TO 'acore'@'%';
+    GRANT ALL ON `acore_characters`.* TO 'acore'@'%';
+    FLUSH PRIVILEGES;
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  namespace: wow
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  serviceName: mysql
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:8.4
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wow-mysql-secret
+                  key: MYSQL_ROOT_PASSWORD
+            - name: MYSQL_DATABASE
+              value: acore_auth
+            - name: MYSQL_USER
+              value: acore
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wow-mysql-secret
+                  key: MYSQL_PASSWORD
+          ports:
+            - name: mysql
+              containerPort: 3306
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - mysqladmin ping -h localhost -u root -p$MYSQL_ROOT_PASSWORD
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - mysqladmin ping -h localhost -u root -p$MYSQL_ROOT_PASSWORD
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/mysql
+            - name: initdb
+              mountPath: /docker-entrypoint-initdb.d
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              memory: 1Gi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: wow-mysql
+        - name: initdb
+          configMap:
+            name: mysql-initdb

--- a/cluster/apps/games/wow/templates/volsync.yaml
+++ b/cluster/apps/games/wow/templates/volsync.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: wow-restic
+  namespace: wow
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  target:
+    name: wow-restic-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: '{{`{{ .REPOSITORY_TEMPLATE }}`}}/wow-mysql'
+        RESTIC_PASSWORD: '{{`{{ .RESTIC_PASSWORD }}`}}'
+        AWS_ACCESS_KEY_ID: '{{`{{ .AWS_ACCESS_KEY_ID }}`}}'
+        AWS_SECRET_ACCESS_KEY: '{{`{{ .AWS_SECRET_ACCESS_KEY }}`}}'
+  data:
+    - secretKey: REPOSITORY_TEMPLATE
+      remoteRef:
+        key: "39b92426-09c4-4a74-8285-b40a00d62b4d" #gitleaks:allow #VOLSYNC_RESTIC_REPOSITORY_TEMPLATE
+    - secretKey: RESTIC_PASSWORD
+      remoteRef:
+        key: "07d70a7a-a6d9-4b0b-af1f-b40a00d649a9" #gitleaks:allow #VOLSYNC_RESTIC_PASSWORD
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: "adb66319-d083-4379-afd5-b40a00d66963" #gitleaks:allow #VOLSYNC_RESTIC_AWS_ACCESS_KEY_ID
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: "70ebd8f2-8270-46d8-8953-b40a00d6854f" #gitleaks:allow #VOLSYNC_RESTIC_AWS_SECRET_ACCESS_KEY
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: wow-mysql
+  namespace: wow
+spec:
+  sourcePVC: wow-mysql
+  trigger:
+    schedule: "0 */12 * * *"
+  restic:
+    copyMethod: Snapshot
+    repository: wow-restic-secret
+    pruneIntervalDays: 14
+    retain:
+      daily: 6
+      weekly: 4
+      monthly: 2

--- a/cluster/apps/games/wow/values.yaml
+++ b/cluster/apps/games/wow/values.yaml
@@ -4,6 +4,8 @@ controllers:
   authserver:
     type: deployment
     replicas: 1
+    annotations:
+      argocd.argoproj.io/sync-wave: "4"
     containers:
       authserver:
         image:
@@ -26,6 +28,8 @@ controllers:
   worldserver:
     type: deployment
     replicas: 1
+    annotations:
+      argocd.argoproj.io/sync-wave: "4"
     initContainers:
       client-data:
         image:

--- a/cluster/apps/games/wow/values.yaml
+++ b/cluster/apps/games/wow/values.yaml
@@ -8,7 +8,7 @@ controllers:
       authserver:
         image:
           repository: ghcr.io/mmalyska/azerothcore-authserver
-          tag: stable@sha256:replaceme
+          tag: 2026-05-10@sha256:6d91682bf12b6a14634630f7d4fe8bc28ad62afa9e115648c31e07c065976093
         env:
           AC_LOGS_DIR: /azerothcore/env/dist/logs
           AC_LOGIN_DATABASE_INFO:
@@ -37,7 +37,7 @@ controllers:
       worldserver:
         image:
           repository: ghcr.io/mmalyska/azerothcore-worldserver
-          tag: stable@sha256:replaceme
+          tag: 2026-05-10@sha256:869f86c3cb21f088c035637ed27081c8483c9cf20d1d3d213b61cc2b57840e35
         env:
           AC_DATA_DIR: /azerothcore/env/dist/data
           AC_LOGS_DIR: /azerothcore/env/dist/logs

--- a/cluster/apps/games/wow/values.yaml
+++ b/cluster/apps/games/wow/values.yaml
@@ -1,0 +1,132 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/refs/tags/app-template-3.6.1/charts/other/app-template/values.schema.json
+---
+controllers:
+  authserver:
+    type: deployment
+    replicas: 1
+    containers:
+      authserver:
+        image:
+          repository: ghcr.io/mmalyska/azerothcore-authserver
+          tag: stable@sha256:replaceme
+        env:
+          AC_LOGS_DIR: /azerothcore/env/dist/logs
+          AC_LOGIN_DATABASE_INFO:
+            valueFrom:
+              secretKeyRef:
+                name: wow-mysql-secret
+                key: AC_LOGIN_DATABASE_INFO
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            memory: 256Mi
+
+  worldserver:
+    type: deployment
+    replicas: 1
+    initContainers:
+      client-data:
+        image:
+          repository: acore/ac-wotlk-client-data
+          tag: master
+        env:
+          DATAPATH: /azerothcore/env/dist/data
+    containers:
+      worldserver:
+        image:
+          repository: ghcr.io/mmalyska/azerothcore-worldserver
+          tag: stable@sha256:replaceme
+        env:
+          AC_DATA_DIR: /azerothcore/env/dist/data
+          AC_LOGS_DIR: /azerothcore/env/dist/logs
+          AC_LOGIN_DATABASE_INFO:
+            valueFrom:
+              secretKeyRef:
+                name: wow-mysql-secret
+                key: AC_LOGIN_DATABASE_INFO
+          AC_WORLD_DATABASE_INFO:
+            valueFrom:
+              secretKeyRef:
+                name: wow-mysql-secret
+                key: AC_WORLD_DATABASE_INFO
+          AC_CHARACTER_DATABASE_INFO:
+            valueFrom:
+              secretKeyRef:
+                name: wow-mysql-secret
+                key: AC_CHARACTER_DATABASE_INFO
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 2Gi
+          limits:
+            memory: 4Gi
+
+  adminer:
+    type: deployment
+    replicas: 1
+    containers:
+      adminer:
+        image:
+          repository: adminer
+          tag: latest
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+
+service:
+  authserver:
+    controller: authserver
+    annotations:
+      lbipam.cilium.io/ips: "192.168.48.29"
+    type: LoadBalancer
+    ports:
+      auth:
+        protocol: TCP
+        port: 3724
+  worldserver:
+    controller: worldserver
+    annotations:
+      lbipam.cilium.io/ips: "192.168.48.29"
+    type: LoadBalancer
+    ports:
+      world:
+        protocol: TCP
+        port: 8085
+      soap:
+        protocol: TCP
+        port: 7878
+  adminer:
+    controller: adminer
+    type: ClusterIP
+    ports:
+      http:
+        protocol: TCP
+        port: 8080
+
+persistence:
+  client-data:
+    enabled: true
+    type: persistentVolumeClaim
+    existingClaim: wow-client-data
+    advancedMounts:
+      worldserver:
+        client-data:
+          - path: /azerothcore/env/dist/data
+        worldserver:
+          - path: /azerothcore/env/dist/data
+            readOnly: true
+  logs:
+    enabled: true
+    type: emptyDir
+    advancedMounts:
+      worldserver:
+        worldserver:
+          - path: /azerothcore/env/dist/logs
+      authserver:
+        authserver:
+          - path: /azerothcore/env/dist/logs

--- a/cluster/apps/games/wow/values.yaml
+++ b/cluster/apps/games/wow/values.yaml
@@ -8,7 +8,7 @@ controllers:
       authserver:
         image:
           repository: ghcr.io/mmalyska/azerothcore-authserver
-          tag: 2026-05-10@sha256:6d91682bf12b6a14634630f7d4fe8bc28ad62afa9e115648c31e07c065976093
+          tag: rolling@sha256:6d91682bf12b6a14634630f7d4fe8bc28ad62afa9e115648c31e07c065976093
         env:
           AC_LOGS_DIR: /azerothcore/env/dist/logs
           AC_LOGIN_DATABASE_INFO:
@@ -37,7 +37,7 @@ controllers:
       worldserver:
         image:
           repository: ghcr.io/mmalyska/azerothcore-worldserver
-          tag: 2026-05-10@sha256:869f86c3cb21f088c035637ed27081c8483c9cf20d1d3d213b61cc2b57840e35
+          tag: rolling@sha256:869f86c3cb21f088c035637ed27081c8483c9cf20d1d3d213b61cc2b57840e35
         env:
           AC_DATA_DIR: /azerothcore/env/dist/data
           AC_LOGS_DIR: /azerothcore/env/dist/logs

--- a/cluster/apps/games/wow/values.yaml
+++ b/cluster/apps/games/wow/values.yaml
@@ -83,6 +83,7 @@ service:
     controller: authserver
     annotations:
       lbipam.cilium.io/ips: "192.168.48.29"
+      lbipam.cilium.io/sharing-key: "wow"
     type: LoadBalancer
     ports:
       auth:
@@ -92,6 +93,7 @@ service:
     controller: worldserver
     annotations:
       lbipam.cilium.io/ips: "192.168.48.29"
+      lbipam.cilium.io/sharing-key: "wow"
     type: LoadBalancer
     ports:
       world:


### PR DESCRIPTION
Deploys AzerothCore 3.3.5a to the cluster as a self-hosted WoW private server for single-player use, accessible at 192.168.48.29 on LAN.

Components:
- MySQL 8.4 StatefulSet with initdb script for all three databases
- authserver + worldserver Deployments via bjw-s common chart (both on shared LoadBalancer IP 192.168.48.29)
- Adminer on envoy-internal HTTPS for DB admin
- db-import PostSync Job (runs AzerothCore migrations + module SQL)
- client-data init container on worldserver (downloads ~30GB game data)
- Volsync Restic backup for MySQL PVC (every 12h)
- ExternalSecret pre-builds DB connection strings to avoid K8s env var ordering issues with bjw-s alphabetical env rendering

Image tags are placeholders (stable@sha256:replaceme) pending CI build from mmalyska/containers feat/azerothcore-images branch.

Modules: mod-solocraft, mod-ah-bot, mod-individual-progression