### PR TITLE
feat(system): add stakater/Reloader to auto-restart on cert rotation

### DIFF
--- a/cluster/apps/system/external-secrets/values.yaml
+++ b/cluster/apps/system/external-secrets/values.yaml
@@ -14,3 +14,5 @@ external-secrets:
       enabled: true
   bitwarden-sdk-server:
     enabled: true
+    deploymentAnnotations:
+      secret.reloader.stakater.com/reload: "bitwarden-tls-certs"

--- a/cluster/apps/system/reloader/Chart.yaml
+++ b/cluster/apps/system/reloader/Chart.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v2
+name: reloader-subchart
+type: application
+version: 1.0.0
+appVersion: "v1.4.16"
+dependencies:
+  - name: reloader
+    version: 2.2.11
+    repository: https://stakater.github.io/stakater-charts

--- a/cluster/apps/system/reloader/app-config.yaml
+++ b/cluster/apps/system/reloader/app-config.yaml
@@ -1,0 +1,6 @@
+- enabled: "true"
+  namespace: reloader
+  syncPolicy:
+    enabled: true
+    selfHeal: true
+    prune: false

--- a/cluster/apps/system/reloader/values.yaml
+++ b/cluster/apps/system/reloader/values.yaml
@@ -1,0 +1,5 @@
+reloader:
+  reloader:
+    logFormat: json
+    serviceMonitor:
+      enabled: true


### PR DESCRIPTION
## Summary

- Adds stakater/Reloader as a new system app (`cluster/apps/system/reloader/`)
- Annotates `bitwarden-sdk-server` deployment with `secret.reloader.stakater.com/reload: bitwarden-tls-certs` so it automatically restarts when cert-manager rotates the TLS cert

## Motivation

cert-manager rotates the `bitwarden-tls-certs` secret at the 60-day mark. The `bitwarden-sdk-server` pod caches its TLS cert at startup and does not hot-reload it from the updated volume. This caused a key mismatch that broke all ExternalSecrets cluster-wide for ~4 days (last occurrence: 2026-05-06).

## Test plan

- [ ] ArgoCD syncs `reloader` app and Reloader pod comes up healthy
- [ ] `bitwarden-sdk-server` deployment has the `secret.reloader.stakater.com/reload` annotation after ArgoCD syncs `external-secrets`
- [ ] All ExternalSecrets remain in `SecretSynced` state
