### PR TITLE
fix(wow): remove AC_UPDATES_ENABLE_DATABASES from worldserver

### DIFF
--- a/cluster/apps/games/wow/values.yaml
+++ b/cluster/apps/games/wow/values.yaml
@@ -45,7 +45,6 @@ controllers:
         env:
           AC_DATA_DIR: /azerothcore/env/dist/data
           AC_LOGS_DIR: /azerothcore/env/dist/logs
-          AC_UPDATES_ENABLE_DATABASES: "1"
           AC_LOGIN_DATABASE_INFO:
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
DB updates are now fully handled by the db-import sync hook job (which applies both core and module SQL). The worldserver no longer needs to run updates itself, avoiding the /azerothcore-src source directory requirement.

Related: mmalyska/containers fix/azerothcore-module-sql-import