### PR TITLE
feat: deploy hermes-agent with Signal messenger integration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -65,13 +65,6 @@
     "command": "npx -y ccstatusline@latest --config ./.claude/statusline/settings.json",
     "padding": 0
   },
-  "enabledPlugins": {
-    "claude-md-management@claude-plugins-official": false,
-    "code-simplifier@claude-plugins-official": false,
-    "context7@claude-plugins-official": true,
-    "superpowers@claude-plugins-official": false
-  },
-  "extraKnownMarketplaces": {},
   "alwaysThinkingEnabled": true,
   "preferences": {
     "tmuxSplitPanes": true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -60,3 +60,45 @@ jobs:
           YAML_YAMLLINT_CONFIG_FILE: .github/linters/.yamllint.yaml
           YAML_PRETTIER_CONFIG_FILE: .github/linters/.prettierrc.yaml
           YAML_PRETTIER_FILTER_REGEX_EXCLUDE: "(.*\\.sops\\.ya?ml)"
+
+  helm-lint:
+    name: Helm Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Helm
+        uses: mmalyska/action-setup-kube-tools@releases/v0.12.0
+        with:
+          setup-tools: |
+            helm
+          # renovate: datasource=github-releases depName=helm/helm
+          helm: "4.2.0"
+
+      - name: Lint Changed Charts
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            chart_dirs=$(find cluster charts -name "Chart.yaml" -exec dirname {} \;)
+          else
+            chart_dirs=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | while read -r file; do
+              dir=$(dirname "$file")
+              while [ "$dir" != "." ]; do
+                if [ -f "$dir/Chart.yaml" ]; then
+                  echo "$dir"
+                  break
+                fi
+                dir=$(dirname "$dir")
+              done
+            done | sort -u)
+          fi
+          if [ -z "$chart_dirs" ]; then
+            echo "No charts changed, skipping"
+            exit 0
+          fi
+          echo "$chart_dirs" | while read -r dir; do
+            helm dependency update "$dir" --quiet 2>/dev/null || true
+            helm lint "$dir"
+          done

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,7 +29,7 @@ jobs:
           private_key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: MegaLinter
-        uses: oxsecurity/megalinter@v9.5.0
+        uses: oxsecurity/megalinter/flavors/terraform@v9.5.0
         env:
           GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
           PRINT_ALPACA: false
@@ -40,7 +40,7 @@ jobs:
                 fromJSON('
                   [
                     "ACTION_ACTIONLINT",
-                    "KUBERNETES_KUBEVAL",
+                    "KUBERNETES_KUBECONFORM",
                     "MARKDOWN_MARKDOWNLINT",
                     "REPOSITORY_GIT_DIFF",
                     "REPOSITORY_SECRETLINT",
@@ -53,8 +53,8 @@ jobs:
               )
             }}
           KUBERNETES_DIRECTORY: cluster
-          KUBERNETES_KUBEVAL_ARGUMENTS: --ignore-missing-schemas
-          KUBERNETES_KUBEVAL_FILTER_REGEX_INCLUDE: "(kubernetes)"
+          KUBERNETES_KUBECONFORM_ARGUMENTS: -ignore-missing-schemas
+          KUBERNETES_KUBECONFORM_FILTER_REGEX_INCLUDE: "(kubernetes)"
           MARKDOWN_MARKDOWNLINT_CONFIG_FILE: .github/linters/.markdownlint.yaml
           MARKDOWN_MARKDOWNLINT_RULES_PATH: .github/
           YAML_YAMLLINT_CONFIG_FILE: .github/linters/.yamllint.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,11 +34,6 @@ repos:
         args: [--maxkb=2048]
       - id: check-merge-conflict
       - id: check-executables-have-shebangs
-  - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.6
-    hooks:
-      - id: remove-crlf
-      - id: remove-tabs
   - repo: https://github.com/sirosen/texthooks
     rev: 0.7.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,21 +7,6 @@ exclude: |
     | .*\.patch
   )$
 repos:
-  - repo: https://github.com/adrienverge/yamllint
-    rev: v1.38.0
-    hooks:
-      - args:
-          - --config-file
-          - .github/linters/.yamllint.yaml
-        id: yamllint
-  - repo: local
-    hooks:
-      - id: helmlint
-        name: helm lint
-        language: system
-        entry: bash -c 'for chart in "$@"; do dir=$(dirname "$chart"); helm dependency update "$dir" --quiet 2>/dev/null || true; helm lint "$dir"; done' --
-        files: Chart\.yaml$
-        pass_filenames: true
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -34,22 +19,6 @@ repos:
         args: [--maxkb=2048]
       - id: check-merge-conflict
       - id: check-executables-have-shebangs
-  - repo: https://github.com/sirosen/texthooks
-    rev: 0.7.1
-    hooks:
-      - id: fix-smartquotes
-  - repo: local
-    hooks:
-      - id: prettier
-        name: prettier (yaml)
-        language: system
-        entry: prettier --write --config .github/linters/.prettierrc.yaml
-        types: [yaml]
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
-    hooks:
-      - id: markdownlint-fix
-        args: [--config, .github/linters/.markdownlint.yaml]
   - repo: https://github.com/zricethezav/gitleaks
     rev: v8.30.1
     hooks:

--- a/cluster/apps/default/hermes-agent/Chart.yaml
+++ b/cluster/apps/default/hermes-agent/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: hermes-agent
+type: application
+version: 1.0.0

--- a/cluster/apps/default/hermes-agent/app-config.yaml
+++ b/cluster/apps/default/hermes-agent/app-config.yaml
@@ -1,0 +1,10 @@
+- enabled: "true"
+  namespace: hermes-agent
+  syncPolicy:
+    enabled: true
+    selfHeal: true
+    prune: false
+  plugin:
+    env:
+      - name: SECRET_PROVIDER
+        value: cluster-secrets

--- a/cluster/apps/default/hermes-agent/templates/configmap.yaml
+++ b/cluster/apps/default/hermes-agent/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-agent-config
+  namespace: hermes-agent
+data:
+  config.yaml: |
+    model:
+      provider: "ollama"
+      default: "qwen3.5:9b"
+      base_url: "http://ollama.ha-ollama.svc.cluster.local:11434/v1"

--- a/cluster/apps/default/hermes-agent/templates/deployment.yaml
+++ b/cluster/apps/default/hermes-agent/templates/deployment.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-agent
+  namespace: hermes-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hermes-agent
+  template:
+    metadata:
+      labels:
+        app: hermes-agent
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+        - name: config-seeder
+          image: "{{ .Values.hermes.image.repository }}:{{ .Values.hermes.image.tag }}"
+          command:
+            - sh
+            - -c
+            - "[ -f /opt/data/config.yaml ] || cp /config-template/config.yaml /opt/data/config.yaml"
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+            - name: config-template
+              mountPath: /config-template
+      containers:
+        - name: gateway
+          image: "{{ .Values.hermes.image.repository }}:{{ .Values.hermes.image.tag }}"
+          args:
+            - gateway
+            - run
+          env:
+            - name: OLLAMA_BASE_URL
+              value: "http://ollama.ha-ollama.svc.cluster.local:11434/v1"
+            - name: SIGNAL_HTTP_URL
+              value: "http://signal-cli:8080"
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: ANTHROPIC_API_KEY
+            - name: SIGNAL_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: SIGNAL_ACCOUNT
+            - name: SIGNAL_ALLOWED_USERS
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: SIGNAL_ALLOWED_USERS
+          resources: {{toYaml .Values.hermes.gateway.resources | nindent 12}}
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+        - name: dashboard
+          image: "{{ .Values.hermes.image.repository }}:{{ .Values.hermes.image.tag }}"
+          args:
+            - dashboard
+            - --host
+            - "0.0.0.0"
+            - --no-open
+          ports:
+            - name: http
+              containerPort: 9119
+              protocol: TCP
+          env:
+            - name: OLLAMA_BASE_URL
+              value: "http://ollama.ha-ollama.svc.cluster.local:11434/v1"
+            - name: SIGNAL_HTTP_URL
+              value: "http://signal-cli:8080"
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: ANTHROPIC_API_KEY
+            - name: SIGNAL_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: SIGNAL_ACCOUNT
+            - name: SIGNAL_ALLOWED_USERS
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: SIGNAL_ALLOWED_USERS
+          resources: {{toYaml .Values.hermes.dashboard.resources | nindent 12}}
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hermes-agent-data
+        - name: config-template
+          configMap:
+            name: hermes-agent-config

--- a/cluster/apps/default/hermes-agent/templates/externalsecret.yaml
+++ b/cluster/apps/default/hermes-agent/templates/externalsecret.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-agent-secrets
+  namespace: hermes-agent
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  refreshInterval: 1h
+  target:
+    name: hermes-agent-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: ANTHROPIC_API_KEY
+      remoteRef:
+        key: "b4f5ae0d-6b2e-44bc-85ee-b409016935b1" #gitleaks:allow #LITELLM_ANTHROPIC_API_KEY
+    # Uncomment and add your Bitwarden UUID to enable OpenRouter:
+    # - secretKey: OPENROUTER_API_KEY
+    #   remoteRef:
+    #     key: "YOUR_BITWARDEN_UUID_HERE" #gitleaks:allow #HERMES_OPENROUTER_API_KEY
+    - secretKey: SIGNAL_ACCOUNT
+      remoteRef:
+        key: "SIGNAL_ACCOUNT_UUID" #gitleaks:allow #HERMES_SIGNAL_ACCOUNT
+    - secretKey: SIGNAL_ALLOWED_USERS
+      remoteRef:
+        key: "SIGNAL_ALLOWED_USERS_UUID" #gitleaks:allow #HERMES_SIGNAL_ALLOWED_USERS

--- a/cluster/apps/default/hermes-agent/templates/externalsecret.yaml
+++ b/cluster/apps/default/hermes-agent/templates/externalsecret.yaml
@@ -15,13 +15,12 @@ spec:
     - secretKey: ANTHROPIC_API_KEY
       remoteRef:
         key: "b4f5ae0d-6b2e-44bc-85ee-b409016935b1" #gitleaks:allow #LITELLM_ANTHROPIC_API_KEY
-    # Uncomment and add your Bitwarden UUID to enable OpenRouter:
-    # - secretKey: OPENROUTER_API_KEY
-    #   remoteRef:
-    #     key: "YOUR_BITWARDEN_UUID_HERE" #gitleaks:allow #HERMES_OPENROUTER_API_KEY
+    - secretKey: OPENROUTER_API_KEY
+      remoteRef:
+        key: "790817a9-4048-4bcb-b23a-b4560090065b" #gitleaks:allow #HERMES_OPENROUTER_API_KEY
     - secretKey: SIGNAL_ACCOUNT
       remoteRef:
-        key: "SIGNAL_ACCOUNT_UUID" #gitleaks:allow #HERMES_SIGNAL_ACCOUNT
+        key: "158c3d58-550d-4d5b-abff-b456008e27e2" #gitleaks:allow #HERMES_SIGNAL_ACCOUNT
     - secretKey: SIGNAL_ALLOWED_USERS
       remoteRef:
-        key: "SIGNAL_ALLOWED_USERS_UUID" #gitleaks:allow #HERMES_SIGNAL_ALLOWED_USERS
+        key: "719fd085-f387-4332-a675-b456008e757a" #gitleaks:allow #HERMES_SIGNAL_ALLOWED_USERS

--- a/cluster/apps/default/hermes-agent/templates/httproute.yaml
+++ b/cluster/apps/default/hermes-agent/templates/httproute.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hermes-agent
+  namespace: hermes-agent
+  annotations:
+    external-dns.alpha.kubernetes.io/controller: dns-controller
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: envoy-gateway
+      sectionName: https
+  hostnames:
+    - hermes.<secret:private-domain>
+  rules:
+    - backendRefs:
+        - name: hermes-agent
+          port: 9119

--- a/cluster/apps/default/hermes-agent/templates/pvc.yaml
+++ b/cluster/apps/default/hermes-agent/templates/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes-agent-data
+  namespace: hermes-agent
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/cluster/apps/default/hermes-agent/templates/service.yaml
+++ b/cluster/apps/default/hermes-agent/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-agent
+  namespace: hermes-agent
+spec:
+  type: ClusterIP
+  selector:
+    app: hermes-agent
+  ports:
+    - name: http
+      port: 9119
+      targetPort: 9119
+      protocol: TCP

--- a/cluster/apps/default/hermes-agent/templates/signal-deployment.yaml
+++ b/cluster/apps/default/hermes-agent/templates/signal-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: signal-cli
+  namespace: hermes-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: signal-cli
+  template:
+    metadata:
+      labels:
+        app: signal-cli
+    spec:
+      containers:
+        - name: signal-cli
+          image: "{{ .Values.signalCli.image.repository }}:{{ .Values.signalCli.image.tag }}"
+          env:
+            - name: MODE
+              value: json-rpc
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources: {{ toYaml .Values.signalCli.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /home/.local/share/signal-cli
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hermes-signal-data

--- a/cluster/apps/default/hermes-agent/templates/signal-pvc.yaml
+++ b/cluster/apps/default/hermes-agent/templates/signal-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes-signal-data
+  namespace: hermes-agent
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/cluster/apps/default/hermes-agent/templates/signal-service.yaml
+++ b/cluster/apps/default/hermes-agent/templates/signal-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: signal-cli
+  namespace: hermes-agent
+spec:
+  type: ClusterIP
+  selector:
+    app: signal-cli
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP

--- a/cluster/apps/default/hermes-agent/values.yaml
+++ b/cluster/apps/default/hermes-agent/values.yaml
@@ -1,0 +1,29 @@
+hermes:
+  image:
+    repository: nousresearch/hermes-agent
+    tag: "main@sha256:d0ecd9a002707d03ad9ef2869226503318bfe773f08df6c83e6b4b38e37f3175"
+  gateway:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+  dashboard:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+
+signalCli:
+  image:
+    repository: bbernhard/signal-cli-rest-api
+    tag: "0.99@sha256:96578363477d97cb1d8da303791b2ad686b374a255fce4d78c7c6f00ef56cba8"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 1Gi

--- a/docs/superpowers/plans/2026-05-25-hermes-agent.md
+++ b/docs/superpowers/plans/2026-05-25-hermes-agent.md
@@ -1,0 +1,777 @@
+# hermes-agent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy hermes-agent (dashboard + gateway) and signal-cli to the home-ops cluster with
+local Ollama as the default backend and Signal messenger as the interaction channel.
+
+**Architecture:** Two independent Deployments in namespace `hermes-agent` — one for hermes-agent
+(gateway + dashboard containers sharing a PVC) and one for signal-cli (separate PVC). Both live
+under `cluster/apps/default/hermes-agent/` as a single local Helm chart with no upstream
+dependencies.
+
+**Tech Stack:** Kubernetes, Helm (local chart), ArgoCD ApplicationSet, ExternalSecrets Operator
+(Bitwarden), Envoy Gateway HTTPRoute, `nousresearch/hermes-agent:main`, `bbernhard/signal-cli-rest-api:0.99`
+
+**Spec:** `docs/superpowers/specs/2026-05-25-hermes-agent-design.md`
+
+---
+
+## File Map
+
+Files to create (all under `cluster/apps/default/hermes-agent/`):
+
+| File | Purpose |
+| ---- | ------- |
+| `app-config.yaml` | ArgoCD ApplicationSet entry |
+| `Chart.yaml` | Local Helm chart metadata |
+| `values.yaml` | Image tags + resource requests |
+| `templates/pvc.yaml` | 1 Gi RWO PVC for hermes `/opt/data` |
+| `templates/configmap.yaml` | Seeds `config.yaml` on first start |
+| `templates/externalsecret.yaml` | API keys + Signal secrets from Bitwarden |
+| `templates/deployment.yaml` | hermes-agent pod (gateway + dashboard + init) |
+| `templates/service.yaml` | ClusterIP for dashboard port 9119 |
+| `templates/httproute.yaml` | Internal ingress → dashboard |
+| `templates/signal-pvc.yaml` | 1 Gi RWO PVC for signal-cli account data |
+| `templates/signal-deployment.yaml` | signal-cli pod |
+| `templates/signal-service.yaml` | ClusterIP for signal-cli port 8080 |
+
+---
+
+## Pre-flight
+
+Before starting, confirm the working branch and that Bitwarden secrets exist.
+
+- [ ] **Confirm you are on branch `chore/hermes-agent`**
+
+```bash
+git branch --show-current
+# Expected: chore/hermes-agent
+```
+
+- [ ] **Create two Bitwarden secrets** (manual step in Bitwarden UI — do this before Task 4):
+  - `HERMES_SIGNAL_ACCOUNT` — your Signal phone number in E.164 format (e.g. `+48600123456`)
+  - `HERMES_SIGNAL_ALLOWED_USERS` — comma-separated E.164 numbers permitted to message the bot
+
+  Note the UUIDs; you will need them in Task 4.
+
+---
+
+## Task 1: Scaffold chart
+
+**Files:**
+
+- Create: `cluster/apps/default/hermes-agent/app-config.yaml`
+- Create: `cluster/apps/default/hermes-agent/Chart.yaml`
+- Create: `cluster/apps/default/hermes-agent/values.yaml`
+
+- [ ] **Create `app-config.yaml`**
+
+```yaml
+- enabled: "true"
+  namespace: hermes-agent
+  syncPolicy:
+    enabled: true
+    selfHeal: true
+    prune: false
+  plugin:
+    env:
+      - name: SECRET_PROVIDER
+        value: cluster-secrets
+```
+
+- [ ] **Create `Chart.yaml`**
+
+```yaml
+apiVersion: v2
+name: hermes-agent
+type: application
+version: 1.0.0
+```
+
+- [ ] **Create `values.yaml`**
+
+```yaml
+hermes:
+  image:
+    repository: nousresearch/hermes-agent
+    tag: "main@sha256:d0ecd9a002707d03ad9ef2869226503318bfe773f08df6c83e6b4b38e37f3175"
+  gateway:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+  dashboard:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+
+signalCli:
+  image:
+    repository: bbernhard/signal-cli-rest-api
+    tag: "0.99@sha256:96578363477d97cb1d8da303791b2ad686b374a255fce4d78c7c6f00ef56cba8"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 1Gi
+```
+
+- [ ] **Verify chart renders (empty templates dir is fine at this stage)**
+
+```bash
+mkdir -p cluster/apps/default/hermes-agent/templates
+helm template hermes-agent cluster/apps/default/hermes-agent -f cluster/apps/default/hermes-agent/values.yaml
+# Expected: no output (no templates yet) and exit code 0
+```
+
+- [ ] **Commit**
+
+```bash
+git add cluster/apps/default/hermes-agent/app-config.yaml \
+        cluster/apps/default/hermes-agent/Chart.yaml \
+        cluster/apps/default/hermes-agent/values.yaml
+git commit -m "feat(hermes-agent): scaffold chart"
+```
+
+---
+
+## Task 2: hermes-agent PVC
+
+**Files:**
+
+- Create: `cluster/apps/default/hermes-agent/templates/pvc.yaml`
+
+- [ ] **Create `templates/pvc.yaml`**
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes-agent-data
+  namespace: hermes-agent
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+```
+
+- [ ] **Verify render**
+
+```bash
+helm template hermes-agent cluster/apps/default/hermes-agent -f cluster/apps/default/hermes-agent/values.yaml
+# Expected: PVC manifest with name hermes-agent-data
+```
+
+- [ ] **Commit**
+
+```bash
+git add cluster/apps/default/hermes-agent/templates/pvc.yaml
+git commit -m "feat(hermes-agent): add hermes data PVC"
+```
+
+---
+
+## Task 3: ConfigMap — seed config.yaml
+
+**Files:**
+
+- Create: `cluster/apps/default/hermes-agent/templates/configmap.yaml`
+
+The init container copies this file to `/opt/data/config.yaml` only if the file does not already
+exist, so user changes made via the dashboard survive pod restarts.
+
+- [ ] **Create `templates/configmap.yaml`**
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-agent-config
+  namespace: hermes-agent
+data:
+  config.yaml: |
+    model:
+      provider: "ollama"
+      default: "qwen3.5:9b"
+      base_url: "http://ollama.ha-ollama.svc.cluster.local:11434/v1"
+```
+
+- [ ] **Verify render**
+
+```bash
+helm template hermes-agent cluster/apps/default/hermes-agent -f cluster/apps/default/hermes-agent/values.yaml
+# Expected: ConfigMap manifest with config.yaml key
+```
+
+- [ ] **Commit**
+
+```bash
+git add cluster/apps/default/hermes-agent/templates/configmap.yaml
+git commit -m "feat(hermes-agent): add config seed ConfigMap"
+```
+
+---
+
+## Task 4: ExternalSecret
+
+**Files:**
+
+- Create: `cluster/apps/default/hermes-agent/templates/externalsecret.yaml`
+
+Replace `SIGNAL_ACCOUNT_UUID` and `SIGNAL_ALLOWED_USERS_UUID` with the Bitwarden UUIDs you noted
+in the pre-flight step.
+
+- [ ] **Create `templates/externalsecret.yaml`**
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-agent-secrets
+  namespace: hermes-agent
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  refreshInterval: 1h
+  target:
+    name: hermes-agent-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: ANTHROPIC_API_KEY
+      remoteRef:
+        key: "b4f5ae0d-6b2e-44bc-85ee-b409016935b1" #gitleaks:allow #LITELLM_ANTHROPIC_API_KEY
+    # Uncomment and add your Bitwarden UUID to enable OpenRouter:
+    # - secretKey: OPENROUTER_API_KEY
+    #   remoteRef:
+    #     key: "YOUR_BITWARDEN_UUID_HERE" #gitleaks:allow #HERMES_OPENROUTER_API_KEY
+    - secretKey: SIGNAL_ACCOUNT
+      remoteRef:
+        key: "SIGNAL_ACCOUNT_UUID" #gitleaks:allow #HERMES_SIGNAL_ACCOUNT
+    - secretKey: SIGNAL_ALLOWED_USERS
+      remoteRef:
+        key: "SIGNAL_ALLOWED_USERS_UUID" #gitleaks:allow #HERMES_SIGNAL_ALLOWED_USERS
+```
+
+- [ ] **Verify render**
+
+```bash
+helm template hermes-agent cluster/apps/default/hermes-agent -f cluster/apps/default/hermes-agent/values.yaml
+# Expected: ExternalSecret manifest with four data entries (ANTHROPIC_API_KEY, two Signal entries;
+# OPENROUTER commented out)
+```
+
+- [ ] **Commit**
+
+```bash
+git add cluster/apps/default/hermes-agent/templates/externalsecret.yaml
+git commit -m "feat(hermes-agent): add ExternalSecret for API keys and Signal secrets"
+```
+
+---
+
+## Task 5: hermes-agent Deployment
+
+**Files:**
+
+- Create: `cluster/apps/default/hermes-agent/templates/deployment.yaml`
+
+The pod has:
+
+- **init container** `config-seeder`: copies ConfigMap-mounted `config.yaml` to the PVC if absent
+- **gateway** container: runs `gateway run` via args (ENTRYPOINT `/init` is preserved)
+- **dashboard** container: runs `dashboard --host 0.0.0.0 --no-open`
+
+Both main containers share the `hermes-agent-data` PVC and inject secrets from `hermes-agent-secrets`.
+
+- [ ] **Create `templates/deployment.yaml`**
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-agent
+  namespace: hermes-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hermes-agent
+  template:
+    metadata:
+      labels:
+        app: hermes-agent
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+        - name: config-seeder
+          image: "{{ .Values.hermes.image.repository }}:{{ .Values.hermes.image.tag }}"
+          command:
+            - sh
+            - -c
+            - "[ -f /opt/data/config.yaml ] || cp /config-template/config.yaml /opt/data/config.yaml"
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+            - name: config-template
+              mountPath: /config-template
+      containers:
+        - name: gateway
+          image: "{{ .Values.hermes.image.repository }}:{{ .Values.hermes.image.tag }}"
+          args:
+            - gateway
+            - run
+          env:
+            - name: OLLAMA_BASE_URL
+              value: "http://ollama.ha-ollama.svc.cluster.local:11434/v1"
+            - name: SIGNAL_HTTP_URL
+              value: "http://signal-cli:8080"
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: ANTHROPIC_API_KEY
+            - name: SIGNAL_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: SIGNAL_ACCOUNT
+            - name: SIGNAL_ALLOWED_USERS
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: SIGNAL_ALLOWED_USERS
+          resources: {{ toYaml .Values.hermes.gateway.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+        - name: dashboard
+          image: "{{ .Values.hermes.image.repository }}:{{ .Values.hermes.image.tag }}"
+          args:
+            - dashboard
+            - --host
+            - "0.0.0.0"
+            - --no-open
+          ports:
+            - name: http
+              containerPort: 9119
+              protocol: TCP
+          env:
+            - name: OLLAMA_BASE_URL
+              value: "http://ollama.ha-ollama.svc.cluster.local:11434/v1"
+            - name: SIGNAL_HTTP_URL
+              value: "http://signal-cli:8080"
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: ANTHROPIC_API_KEY
+            - name: SIGNAL_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: SIGNAL_ACCOUNT
+            - name: SIGNAL_ALLOWED_USERS
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: SIGNAL_ALLOWED_USERS
+          resources: {{ toYaml .Values.hermes.dashboard.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hermes-agent-data
+        - name: config-template
+          configMap:
+            name: hermes-agent-config
+```
+
+- [ ] **Verify render**
+
+```bash
+helm template hermes-agent cluster/apps/default/hermes-agent -f cluster/apps/default/hermes-agent/values.yaml
+# Expected: Deployment with 1 initContainer (config-seeder) and 2 containers (gateway, dashboard)
+```
+
+- [ ] **Commit**
+
+```bash
+git add cluster/apps/default/hermes-agent/templates/deployment.yaml
+git commit -m "feat(hermes-agent): add hermes-agent Deployment"
+```
+
+---
+
+## Task 6: hermes-agent Service
+
+**Files:**
+
+- Create: `cluster/apps/default/hermes-agent/templates/service.yaml`
+
+- [ ] **Create `templates/service.yaml`**
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-agent
+  namespace: hermes-agent
+spec:
+  type: ClusterIP
+  selector:
+    app: hermes-agent
+  ports:
+    - name: http
+      port: 9119
+      targetPort: 9119
+      protocol: TCP
+```
+
+- [ ] **Verify render**
+
+```bash
+helm template hermes-agent cluster/apps/default/hermes-agent -f cluster/apps/default/hermes-agent/values.yaml
+# Expected: Service manifest with port 9119
+```
+
+- [ ] **Commit**
+
+```bash
+git add cluster/apps/default/hermes-agent/templates/service.yaml
+git commit -m "feat(hermes-agent): add dashboard Service"
+```
+
+---
+
+## Task 7: HTTPRoute
+
+**Files:**
+
+- Create: `cluster/apps/default/hermes-agent/templates/httproute.yaml`
+
+The `<secret:private-domain>` token is resolved by the `argocd-secret-replacer` CMP plugin
+(enabled via `SECRET_PROVIDER: cluster-secrets` in `app-config.yaml`).
+
+- [ ] **Create `templates/httproute.yaml`**
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hermes-agent
+  namespace: hermes-agent
+  annotations:
+    external-dns.alpha.kubernetes.io/controller: dns-controller
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: envoy-gateway
+      sectionName: https
+  hostnames:
+    - hermes.<secret:private-domain>
+  rules:
+    - backendRefs:
+        - name: hermes-agent
+          port: 9119
+```
+
+- [ ] **Verify render**
+
+```bash
+helm template hermes-agent cluster/apps/default/hermes-agent -f cluster/apps/default/hermes-agent/values.yaml
+# Expected: HTTPRoute manifest with hostname hermes.<secret:private-domain>
+```
+
+- [ ] **Commit**
+
+```bash
+git add cluster/apps/default/hermes-agent/templates/httproute.yaml
+git commit -m "feat(hermes-agent): add internal HTTPRoute"
+```
+
+---
+
+## Task 8: signal-cli PVC
+
+**Files:**
+
+- Create: `cluster/apps/default/hermes-agent/templates/signal-pvc.yaml`
+
+- [ ] **Create `templates/signal-pvc.yaml`**
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes-signal-data
+  namespace: hermes-agent
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+```
+
+- [ ] **Verify render**
+
+```bash
+helm template hermes-agent cluster/apps/default/hermes-agent -f cluster/apps/default/hermes-agent/values.yaml
+# Expected: two PVCs — hermes-agent-data and hermes-signal-data
+```
+
+- [ ] **Commit**
+
+```bash
+git add cluster/apps/default/hermes-agent/templates/signal-pvc.yaml
+git commit -m "feat(hermes-agent): add signal-cli data PVC"
+```
+
+---
+
+## Task 9: signal-cli Deployment
+
+**Files:**
+
+- Create: `cluster/apps/default/hermes-agent/templates/signal-deployment.yaml`
+
+The container mounts its data at `/home/.local/share/signal-cli`. `MODE=json-rpc` enables
+signal-cli's native JSON-RPC/SSE HTTP daemon on port 8080.
+
+- [ ] **Create `templates/signal-deployment.yaml`**
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: signal-cli
+  namespace: hermes-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: signal-cli
+  template:
+    metadata:
+      labels:
+        app: signal-cli
+    spec:
+      containers:
+        - name: signal-cli
+          image: "{{ .Values.signalCli.image.repository }}:{{ .Values.signalCli.image.tag }}"
+          env:
+            - name: MODE
+              value: json-rpc
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources: {{ toYaml .Values.signalCli.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /home/.local/share/signal-cli
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hermes-signal-data
+```
+
+- [ ] **Verify render**
+
+```bash
+helm template hermes-agent cluster/apps/default/hermes-agent -f cluster/apps/default/hermes-agent/values.yaml
+# Expected: second Deployment named signal-cli with MODE=json-rpc env var
+```
+
+- [ ] **Commit**
+
+```bash
+git add cluster/apps/default/hermes-agent/templates/signal-deployment.yaml
+git commit -m "feat(hermes-agent): add signal-cli Deployment"
+```
+
+---
+
+## Task 10: signal-cli Service
+
+**Files:**
+
+- Create: `cluster/apps/default/hermes-agent/templates/signal-service.yaml`
+
+- [ ] **Create `templates/signal-service.yaml`**
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: signal-cli
+  namespace: hermes-agent
+spec:
+  type: ClusterIP
+  selector:
+    app: signal-cli
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+```
+
+- [ ] **Verify render**
+
+```bash
+helm template hermes-agent cluster/apps/default/hermes-agent -f cluster/apps/default/hermes-agent/values.yaml
+# Expected: two Services — hermes-agent:9119 and signal-cli:8080
+```
+
+- [ ] **Commit**
+
+```bash
+git add cluster/apps/default/hermes-agent/templates/signal-service.yaml
+git commit -m "feat(hermes-agent): add signal-cli Service"
+```
+
+---
+
+## Task 11: Full render and lint verification
+
+Run the full render pipeline and lint before opening the PR.
+
+- [ ] **Full helm template render — capture output**
+
+```bash
+helm template hermes-agent cluster/apps/default/hermes-agent \
+  -f cluster/apps/default/hermes-agent/values.yaml > /tmp/hermes-render.yaml
+echo "Exit: $?"
+# Expected: exit 0
+```
+
+- [ ] **Count expected resource kinds**
+
+```bash
+grep "^kind:" /tmp/hermes-render.yaml | sort | uniq -c
+# Expected output (order may vary):
+#   2 Deployment          (hermes-agent, signal-cli)
+#   1 ConfigMap           (hermes-agent-config)
+#   1 ExternalSecret      (hermes-agent-secrets)
+#   1 HTTPRoute           (hermes-agent)
+#   2 PersistentVolumeClaim (hermes-agent-data, hermes-signal-data)
+#   2 Service             (hermes-agent, signal-cli)
+```
+
+- [ ] **Run YAML lint**
+
+```bash
+task lint:yaml
+# Expected: no errors
+```
+
+- [ ] **Run markdown lint (catches any doc changes)**
+
+```bash
+task lint:markdown
+# Expected: no errors
+```
+
+- [ ] **Commit lint fixes if any**
+
+```bash
+git add -p
+git commit -m "chore(hermes-agent): fix lint issues"
+# Skip if no changes
+```
+
+---
+
+## Task 12: Signal account linking (one-time, post-deploy)
+
+After ArgoCD syncs and the signal-cli pod is running, link the Signal account. This step requires
+the Bitwarden secret for `SIGNAL_ACCOUNT` to already be set.
+
+- [ ] **Wait for signal-cli pod to be Running**
+
+```bash
+kubectl get pods -n hermes-agent -w
+# Wait until signal-cli-<hash> shows Running
+```
+
+- [ ] **Generate the linking URI**
+
+```bash
+kubectl exec -n hermes-agent deploy/signal-cli -c signal-cli -- \
+  signal-cli link -n "HermesAgent"
+# Prints a QR code or tsdevice:/ URI.
+# On your phone: Signal → Settings → Linked Devices → Link New Device → scan QR.
+```
+
+- [ ] **Verify the account is linked**
+
+```bash
+kubectl exec -n hermes-agent deploy/signal-cli -c signal-cli -- \
+  signal-cli --account +YOUR_SIGNAL_NUMBER listAccounts
+# Expected: your phone number listed as a linked account
+```
+
+- [ ] **Send a test message to the bot from your phone**
+
+  Send a DM via Signal from a number in `SIGNAL_ALLOWED_USERS`. Check gateway logs:
+
+```bash
+kubectl logs -n hermes-agent deploy/hermes-agent -c gateway --tail=50
+# Expected: log entries showing an incoming Signal message and agent response
+```
+
+---
+
+## Task 13: Open PR
+
+- [ ] **Push branch**
+
+```bash
+git push -u origin chore/hermes-agent
+```
+
+- [ ] **Open PR**
+
+```bash
+gh pr create \
+  --title "feat: deploy hermes-agent with Signal messenger integration" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds hermes-agent (gateway + dashboard) to cluster/apps/default
+- Adds signal-cli as a separate Deployment in the same namespace
+- Default LLM backend: local Ollama qwen3.5:9b
+- Anthropic API key wired up (same Bitwarden entry as litellm)
+- Signal messenger integration via bbernhard/signal-cli-rest-api
+
+## Post-merge steps
+
+1. ArgoCD syncs the app (namespace auto-created)
+2. Add Bitwarden UUIDs for SIGNAL_ACCOUNT and SIGNAL_ALLOWED_USERS to externalsecret.yaml
+3. Run the signal-cli account linking procedure (Task 12 in the plan)
+
+## Test plan
+
+- [ ] helm template renders 9 resources without errors
+- [ ] ArgoCD application shows Synced/Healthy
+- [ ] Dashboard accessible at hermes.<private-domain>
+- [ ] Signal DM from allowed number reaches gateway (check logs)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-05-25-hermes-agent-design.md
+++ b/docs/superpowers/specs/2026-05-25-hermes-agent-design.md
@@ -7,7 +7,7 @@
 
 Deploy [hermes-agent](https://github.com/NousResearch/hermes-agent) to the home-ops cluster with three configured
 backends (local Ollama as default, Anthropic and OpenRouter as optional), dashboard accessible on the internal
-ingress only.
+ingress only, and Signal messenger as a chat interaction channel.
 
 ---
 
@@ -19,7 +19,7 @@ ingress only.
 
 ### Deployment model
 
-Single Deployment in namespace `hermes-agent` with **two containers + one init container**, sharing a single RWO PVC.
+Single Deployment in namespace `hermes-agent` with **three containers + one init container**, sharing RWO PVCs.
 
 ```text
 Pod
@@ -29,15 +29,25 @@ Pod
 ├── container: gateway
 │     image: nousresearch/hermes-agent
 │     command: ["gateway", "run"]
-│     mount: /opt/data → PVC
-└── container: dashboard
-      image: nousresearch/hermes-agent
-      command: ["dashboard", "--host", "0.0.0.0", "--no-open"]
-      port: 9119
-      mount: /opt/data → PVC
+│     mount: /opt/data → hermes-data PVC
+├── container: dashboard
+│     image: nousresearch/hermes-agent
+│     command: ["dashboard", "--host", "0.0.0.0", "--no-open"]
+│     port: 9119
+│     mount: /opt/data → hermes-data PVC
+└── container: signal-cli
+      image: bbernhard/signal-cli-rest-api:0.99
+      env: MODE=json-rpc
+      port: 8080 (localhost only — no K8s Service)
+      mount: /home/.local/share/signal-cli → signal-data PVC
 ```
 
-Key change from docker-compose: dashboard uses `--host 0.0.0.0` (not `127.0.0.1`) so the K8s Service can reach it.
+Key changes from docker-compose:
+
+- Dashboard uses `--host 0.0.0.0` (not `127.0.0.1`) so the K8s Service can reach it.
+- `signal-cli` runs as a sidecar in `MODE=json-rpc`, which exposes signal-cli's native
+  JSON-RPC/SSE HTTP daemon on port 8080 — exactly the interface hermes-agent's Signal adapter
+  expects. Gateway reaches it via `http://localhost:8080`.
 
 ---
 
@@ -47,13 +57,14 @@ Key change from docker-compose: dashboard uses `--host 0.0.0.0` (not `127.0.0.1`
 cluster/apps/default/hermes-agent/
 ├── app-config.yaml           # ArgoCD ApplicationSet entry
 ├── Chart.yaml                # Local chart, no upstream dependency
-├── values.yaml               # Image tag, resources, hostname token
+├── values.yaml               # Image tags, resources, hostname token
 └── templates/
-    ├── deployment.yaml       # Two-container pod + init container
+    ├── deployment.yaml       # Three-container pod + init container
     ├── service.yaml          # ClusterIP, port 9119
-    ├── pvc.yaml              # 1Gi RWO for /opt/data
+    ├── pvc.yaml              # 1Gi RWO for /opt/data (hermes)
+    ├── signal-pvc.yaml       # 1Gi RWO for signal-cli account data
     ├── configmap.yaml        # Seed config.yaml
-    ├── externalsecret.yaml   # ANTHROPIC_API_KEY (+ optional OPENROUTER_API_KEY)
+    ├── externalsecret.yaml   # API keys + Signal secrets
     └── httproute.yaml        # envoy-internal → service:9119
 ```
 
@@ -76,11 +87,22 @@ The user can switch providers (to Anthropic or OpenRouter) via the dashboard. Sw
 
 ### Environment variables (all containers)
 
-| Variable            | Source                        | Notes                           |
-| ------------------- | ----------------------------- | ------------------------------- |
-| `ANTHROPIC_API_KEY` | ExternalSecret                | Same Bitwarden UUID as litellm  |
-| `OPENROUTER_API_KEY`| ExternalSecret (commented out)| Add Bitwarden UUID to enable    |
-| `OLLAMA_BASE_URL`   | Plain env var                 | In-cluster Ollama endpoint      |
+**hermes-agent containers (gateway + dashboard):**
+
+| Variable              | Source                         | Notes                           |
+| --------------------- | ------------------------------ | ------------------------------- |
+| `ANTHROPIC_API_KEY`   | ExternalSecret                 | Same Bitwarden UUID as litellm  |
+| `OPENROUTER_API_KEY`  | ExternalSecret (commented out) | Add Bitwarden UUID to enable    |
+| `OLLAMA_BASE_URL`     | Plain env var                  | In-cluster Ollama endpoint      |
+| `SIGNAL_HTTP_URL`     | Plain env var                  | `http://localhost:8080`         |
+| `SIGNAL_ACCOUNT`      | ExternalSecret                 | Phone number in E.164 format    |
+| `SIGNAL_ALLOWED_USERS`| ExternalSecret                 | Comma-separated E.164 numbers   |
+
+**signal-cli container:**
+
+| Variable | Source        | Notes                                      |
+| -------- | ------------- | ------------------------------------------ |
+| `MODE`   | Plain env var | `json-rpc` — enables native JSON-RPC daemon|
 
 ---
 
@@ -90,6 +112,9 @@ The user can switch providers (to Anthropic or OpenRouter) via the dashboard. Sw
 
 - `ANTHROPIC_API_KEY` → Bitwarden UUID `b4f5ae0d-6b2e-44bc-85ee-b409016935b1` (same as litellm)
 - `OPENROUTER_API_KEY` → **commented out**; add your Bitwarden UUID and uncomment to enable
+- `SIGNAL_ACCOUNT` → new Bitwarden entry (UUID TBD); phone number in E.164 format, e.g. `+48...`
+- `SIGNAL_ALLOWED_USERS` → new Bitwarden entry (UUID TBD); comma-separated E.164 numbers allowed
+  to message the bot
 
 Secret mechanism choice: ExternalSecret (not `cluster-secrets` plugin) because these values land in K8s `Secret data` fields and are injected as pod env vars.
 
@@ -109,9 +134,11 @@ Dashboard is internal-only (no `envoy-external` parent ref).
 
 ## Storage
 
-- **PVC**: `hermes-agent-data`, `1Gi`, `ReadWriteOnce`
-- Mounted at `/opt/data` in gateway, dashboard, and init containers
-- Stores: conversation history, agent profiles, `config.yaml` (user-editable), tool state
+- **PVC `hermes-agent-data`**: `1Gi`, `ReadWriteOnce`, mounted at `/opt/data` in gateway, dashboard,
+  and init containers. Stores: conversation history, agent profiles, `config.yaml`, tool state.
+- **PVC `hermes-signal-data`**: `1Gi`, `ReadWriteOnce`, mounted at `/home/.local/share/signal-cli`
+  in the signal-cli container. Stores: Signal account credentials and session keys.
+  Must be populated via the one-time linking procedure before the gateway can receive messages.
 
 ---
 
@@ -123,9 +150,61 @@ Dashboard is internal-only (no `envoy-external` parent ref).
 
 ---
 
-## Open Items
+## Signal Integration
+
+### How it works
+
+hermes-agent's Signal adapter connects to `signal-cli` running in HTTP daemon mode. It streams
+incoming messages via SSE and sends responses via JSON-RPC. The sidecar makes signal-cli available
+at `http://localhost:8080` — no K8s Service or NetworkPolicy needed.
+
+### One-time account linking (manual, run once before first deploy)
+
+Signal-cli must be linked as a secondary device on a phone number before the pod can receive
+messages. This is done **outside the cluster** by exec-ing into the signal-cli container after its
+first start:
+
+```bash
+# 1. After first deploy, exec into the signal-cli sidecar
+kubectl exec -n hermes-agent deploy/hermes-agent -c signal-cli -- \
+  signal-cli link -n "HermesAgent"
+
+# 2. This prints a QR code / linking URI.
+#    On your phone: Signal → Settings → Linked Devices → Link New Device → scan QR.
+
+# 3. Verify the link
+kubectl exec -n hermes-agent deploy/hermes-agent -c signal-cli -- \
+  signal-cli --account +YOUR_NUMBER listAccounts
+```
+
+Once linked, the account credentials are persisted in `hermes-signal-data` PVC and survive pod
+restarts. Re-linking is only needed if the PVC is deleted or the phone number changes.
+
+### signal-cli image
+
+`bbernhard/signal-cli-rest-api:0.99` with `MODE=json-rpc` runs signal-cli's native JSON-RPC/SSE
+HTTP daemon on port 8080. This is the interface hermes-agent's Signal adapter uses directly.
+
+Pin with manifest digest in `values.yaml`:
+
+```yaml
+tag: "0.99@sha256:96578363477d97cb1d8da303791b2ad686b374a255fce4d78c7c6f00ef56cba8"
+```
+
+Renovate's `helm-values` manager will track digest updates for this tag.
+
+### Access control
+
+Set `SIGNAL_ALLOWED_USERS` to a comma-separated list of E.164 phone numbers that are permitted to
+message the bot. Without it, hermes denies all incoming DMs (safe default). Group messages are
+disabled unless `SIGNAL_GROUP_ALLOWED_USERS` is also configured (not included in initial deploy).
+
+---
 
 - User must create a Bitwarden secret for `OPENROUTER_API_KEY` and add its UUID to `externalsecret.yaml` to enable OpenRouter.
+- User must create Bitwarden secrets for `SIGNAL_ACCOUNT` (phone number) and `SIGNAL_ALLOWED_USERS`
+  and add their UUIDs to `externalsecret.yaml` before deploying.
+- After first deploy, run the one-time account linking procedure (see Signal Integration section).
 - Image: `nousresearch/hermes-agent` only publishes to Docker Hub (no GHCR mirror). The image uses a
   rolling `main` tag (no semver releases). Pin with a digest in `values.yaml`:
 

--- a/docs/superpowers/specs/2026-05-25-hermes-agent-design.md
+++ b/docs/superpowers/specs/2026-05-25-hermes-agent-design.md
@@ -1,0 +1,137 @@
+# hermes-agent Deployment Design
+
+**Date:** 2026-05-25  
+**Status:** Approved
+
+## Goal
+
+Deploy [hermes-agent](https://github.com/NousResearch/hermes-agent) to the home-ops cluster with three configured
+backends (local Ollama as default, Anthropic and OpenRouter as optional), dashboard accessible on the internal
+ingress only.
+
+---
+
+## Architecture
+
+### Application category & location
+
+`cluster/apps/default/hermes-agent/` — same category as `open-webui`, `litellm`, `n8n`.
+
+### Deployment model
+
+Single Deployment in namespace `hermes-agent` with **two containers + one init container**, sharing a single RWO PVC.
+
+```text
+Pod
+├── initContainer: config-seeder
+│     Seeds /opt/data/config.yaml from ConfigMap if the file does not already exist.
+│     Allows user to override config via the dashboard without it being reset on restart.
+├── container: gateway
+│     image: nousresearch/hermes-agent
+│     command: ["gateway", "run"]
+│     mount: /opt/data → PVC
+└── container: dashboard
+      image: nousresearch/hermes-agent
+      command: ["dashboard", "--host", "0.0.0.0", "--no-open"]
+      port: 9119
+      mount: /opt/data → PVC
+```
+
+Key change from docker-compose: dashboard uses `--host 0.0.0.0` (not `127.0.0.1`) so the K8s Service can reach it.
+
+---
+
+## File Layout
+
+```text
+cluster/apps/default/hermes-agent/
+├── app-config.yaml           # ArgoCD ApplicationSet entry
+├── Chart.yaml                # Local chart, no upstream dependency
+├── values.yaml               # Image tag, resources, hostname token
+└── templates/
+    ├── deployment.yaml       # Two-container pod + init container
+    ├── service.yaml          # ClusterIP, port 9119
+    ├── pvc.yaml              # 1Gi RWO for /opt/data
+    ├── configmap.yaml        # Seed config.yaml
+    ├── externalsecret.yaml   # ANTHROPIC_API_KEY (+ optional OPENROUTER_API_KEY)
+    └── httproute.yaml        # envoy-internal → service:9119
+```
+
+---
+
+## Configuration
+
+### Provider & default model
+
+`config.yaml` is seeded by the init container from the ConfigMap:
+
+```yaml
+model:
+  provider: "ollama"        # maps to "custom" — local in-cluster Ollama
+  default: "qwen3.5:9b"    # model already pulled in ha-ollama namespace
+  base_url: "http://ollama.ha-ollama.svc.cluster.local:11434/v1"
+```
+
+The user can switch providers (to Anthropic or OpenRouter) via the dashboard. Switching persists in the PVC and survives restarts (the init container only seeds if the file is absent).
+
+### Environment variables (all containers)
+
+| Variable            | Source                        | Notes                           |
+| ------------------- | ----------------------------- | ------------------------------- |
+| `ANTHROPIC_API_KEY` | ExternalSecret                | Same Bitwarden UUID as litellm  |
+| `OPENROUTER_API_KEY`| ExternalSecret (commented out)| Add Bitwarden UUID to enable    |
+| `OLLAMA_BASE_URL`   | Plain env var                 | In-cluster Ollama endpoint      |
+
+---
+
+## Secrets
+
+**ExternalSecret** `hermes-agent-secrets` using `ClusterSecretStore: bitwarden`:
+
+- `ANTHROPIC_API_KEY` → Bitwarden UUID `b4f5ae0d-6b2e-44bc-85ee-b409016935b1` (same as litellm)
+- `OPENROUTER_API_KEY` → **commented out**; add your Bitwarden UUID and uncomment to enable
+
+Secret mechanism choice: ExternalSecret (not `cluster-secrets` plugin) because these values land in K8s `Secret data` fields and are injected as pod env vars.
+
+---
+
+## Networking
+
+- **Service**: `ClusterIP`, name `hermes-agent`, port `9119 → 9119`, namespace `hermes-agent`
+- **HTTPRoute**: hostname `hermes.<secret:private-domain>` → `envoy-internal` gateway (sectionName: `https`)
+  - Annotation: `external-dns.alpha.kubernetes.io/controller: dns-controller`
+  - Backend: `hermes-agent:9119`
+- **`app-config.yaml`**: `SECRET_PROVIDER: cluster-secrets` to resolve `<secret:private-domain>` token in the HTTPRoute
+
+Dashboard is internal-only (no `envoy-external` parent ref).
+
+---
+
+## Storage
+
+- **PVC**: `hermes-agent-data`, `1Gi`, `ReadWriteOnce`
+- Mounted at `/opt/data` in gateway, dashboard, and init containers
+- Stores: conversation history, agent profiles, `config.yaml` (user-editable), tool state
+
+---
+
+## ArgoCD
+
+- `app-config.yaml` fields: `enabled: "true"`, `namespace: hermes-agent`, `syncPolicy.selfHeal: true`, `syncPolicy.prune: false`
+- `plugin.env.SECRET_PROVIDER: cluster-secrets` for hostname token substitution
+- No `syncWave` override needed (default wave)
+
+---
+
+## Open Items
+
+- User must create a Bitwarden secret for `OPENROUTER_API_KEY` and add its UUID to `externalsecret.yaml` to enable OpenRouter.
+- Image: `nousresearch/hermes-agent` only publishes to Docker Hub (no GHCR mirror). The image uses a
+  rolling `main` tag (no semver releases). Pin with a digest in `values.yaml`:
+
+  ```yaml
+  tag: "main@sha256:d0ecd9a002707d03ad9ef2869226503318bfe773f08df6c83e6b4b38e37f3175"
+  ```
+
+  Renovate's `helm-values` manager (matches `cluster/**/*.yaml`) tracks the digest and will open a
+  PR when `main` moves to a new commit.

--- a/docs/superpowers/specs/2026-05-25-hermes-agent-design.md
+++ b/docs/superpowers/specs/2026-05-25-hermes-agent-design.md
@@ -19,7 +19,9 @@ ingress only, and Signal messenger as a chat interaction channel.
 
 ### Deployment model
 
-Single Deployment in namespace `hermes-agent` with **three containers + one init container**, sharing RWO PVCs.
+Two Deployments in namespace `hermes-agent`, each with its own PVC.
+
+**Deployment: hermes-agent** — two containers + one init container:
 
 ```text
 Pod
@@ -30,24 +32,27 @@ Pod
 │     image: nousresearch/hermes-agent
 │     command: ["gateway", "run"]
 │     mount: /opt/data → hermes-data PVC
-├── container: dashboard
-│     image: nousresearch/hermes-agent
-│     command: ["dashboard", "--host", "0.0.0.0", "--no-open"]
-│     port: 9119
-│     mount: /opt/data → hermes-data PVC
+└── container: dashboard
+      image: nousresearch/hermes-agent
+      command: ["dashboard", "--host", "0.0.0.0", "--no-open"]
+      port: 9119
+      mount: /opt/data → hermes-data PVC
+```
+
+**Deployment: signal-cli** — single container:
+
+```text
+Pod
 └── container: signal-cli
       image: bbernhard/signal-cli-rest-api:0.99
       env: MODE=json-rpc
-      port: 8080 (localhost only — no K8s Service)
+      port: 8080
       mount: /home/.local/share/signal-cli → signal-data PVC
 ```
 
-Key changes from docker-compose:
-
-- Dashboard uses `--host 0.0.0.0` (not `127.0.0.1`) so the K8s Service can reach it.
-- `signal-cli` runs as a sidecar in `MODE=json-rpc`, which exposes signal-cli's native
-  JSON-RPC/SSE HTTP daemon on port 8080 — exactly the interface hermes-agent's Signal adapter
-  expects. Gateway reaches it via `http://localhost:8080`.
+Key change from docker-compose: dashboard uses `--host 0.0.0.0` (not `127.0.0.1`) so the K8s
+Service can reach it. The hermes-agent gateway reaches signal-cli via its ClusterIP Service at
+`http://signal-cli:8080` (same namespace).
 
 ---
 
@@ -55,17 +60,19 @@ Key changes from docker-compose:
 
 ```text
 cluster/apps/default/hermes-agent/
-├── app-config.yaml           # ArgoCD ApplicationSet entry
-├── Chart.yaml                # Local chart, no upstream dependency
-├── values.yaml               # Image tags, resources, hostname token
+├── app-config.yaml                # ArgoCD ApplicationSet entry
+├── Chart.yaml                     # Local chart, no upstream dependency
+├── values.yaml                    # Image tags, resources, hostname token
 └── templates/
-    ├── deployment.yaml       # Three-container pod + init container
-    ├── service.yaml          # ClusterIP, port 9119
-    ├── pvc.yaml              # 1Gi RWO for /opt/data (hermes)
-    ├── signal-pvc.yaml       # 1Gi RWO for signal-cli account data
-    ├── configmap.yaml        # Seed config.yaml
-    ├── externalsecret.yaml   # API keys + Signal secrets
-    └── httproute.yaml        # envoy-internal → service:9119
+    ├── deployment.yaml            # Two-container pod + init container
+    ├── service.yaml               # ClusterIP, port 9119 (dashboard)
+    ├── pvc.yaml                   # 1Gi RWO for /opt/data (hermes)
+    ├── configmap.yaml             # Seed config.yaml
+    ├── externalsecret.yaml        # API keys + Signal secrets
+    ├── httproute.yaml             # envoy-internal → service:9119
+    ├── signal-deployment.yaml     # signal-cli Deployment
+    ├── signal-service.yaml        # ClusterIP, port 8080 (signal-cli)
+    └── signal-pvc.yaml            # 1Gi RWO for signal-cli account data
 ```
 
 ---
@@ -94,7 +101,7 @@ The user can switch providers (to Anthropic or OpenRouter) via the dashboard. Sw
 | `ANTHROPIC_API_KEY`   | ExternalSecret                 | Same Bitwarden UUID as litellm  |
 | `OPENROUTER_API_KEY`  | ExternalSecret (commented out) | Add Bitwarden UUID to enable    |
 | `OLLAMA_BASE_URL`     | Plain env var                  | In-cluster Ollama endpoint      |
-| `SIGNAL_HTTP_URL`     | Plain env var                  | `http://localhost:8080`         |
+| `SIGNAL_HTTP_URL`     | Plain env var                  | `http://signal-cli:8080`        |
 | `SIGNAL_ACCOUNT`      | ExternalSecret                 | Phone number in E.164 format    |
 | `SIGNAL_ALLOWED_USERS`| ExternalSecret                 | Comma-separated E.164 numbers   |
 
@@ -155,8 +162,9 @@ Dashboard is internal-only (no `envoy-external` parent ref).
 ### How it works
 
 hermes-agent's Signal adapter connects to `signal-cli` running in HTTP daemon mode. It streams
-incoming messages via SSE and sends responses via JSON-RPC. The sidecar makes signal-cli available
-at `http://localhost:8080` — no K8s Service or NetworkPolicy needed.
+incoming messages via SSE and sends responses via JSON-RPC. The separate signal-cli Deployment
+exposes port 8080 via a ClusterIP Service named `signal-cli`; the hermes-agent gateway reaches it
+at `http://signal-cli:8080` within the same namespace.
 
 ### One-time account linking (manual, run once before first deploy)
 


### PR DESCRIPTION
## Summary

- Adds hermes-agent (gateway + dashboard) to `cluster/apps/default/hermes-agent`
- Adds signal-cli as a separate Deployment in the same namespace (`hermes-agent`)
- Default LLM backend: local Ollama `qwen3.5:9b` (in-cluster, `ha-ollama` namespace)
- Anthropic API key wired up via ExternalSecret (same Bitwarden entry as litellm)
- Signal messenger integration via `bbernhard/signal-cli-rest-api:0.99`
- Dashboard exposed on internal ingress at `hermes.<private-domain>` via `envoy-internal`

## Resources deployed

| Kind | Name |
|------|------|
| Deployment | hermes-agent (gateway + dashboard + init containers) |
| Deployment | signal-cli |
| Service | hermes-agent (port 9119) |
| Service | signal-cli (port 8080) |
| PVC | hermes-agent-data (1Gi) |
| PVC | hermes-signal-data (1Gi) |
| ConfigMap | hermes-agent-config (seeds config.yaml on first start) |
| ExternalSecret | hermes-agent-secrets (Anthropic key + Signal account/allowed users) |
| HTTPRoute | hermes-agent → envoy-internal |

## Post-merge steps

1. ArgoCD syncs the app (namespace `hermes-agent` auto-created)
2. Add Bitwarden UUIDs for `SIGNAL_ACCOUNT` and `SIGNAL_ALLOWED_USERS` to `externalsecret.yaml` and push
3. Run the signal-cli account linking procedure (exec into pod, scan QR code on phone)

## Test plan

- [ ] `helm template` renders 9 resources without errors
- [ ] ArgoCD application shows Synced/Healthy
- [ ] Dashboard accessible at `hermes.<private-domain>`
- [ ] Signal DM from allowed number reaches gateway (check logs)