### PR TITLE
feat(hermes-agent): add Discord integration

### DIFF
--- a/.plans/list.md
+++ b/.plans/list.md
@@ -2,3 +2,4 @@
 
 | Plan | Description | Started |
 |------|-------------|---------|
+| [hermes-agent-discord](../docs/superpowers/plans/2026-05-26-hermes-agent-discord.md) | Add Discord messaging channel to hermes-agent | 2026-05-26 |

--- a/cluster/apps/default/hermes-agent/templates/deployment.yaml
+++ b/cluster/apps/default/hermes-agent/templates/deployment.yaml
@@ -96,6 +96,16 @@ spec:
                 secretKeyRef:
                   name: hermes-agent-secrets
                   key: SIGNAL_HOME_CHANNEL
+            - name: DISCORD_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: DISCORD_BOT_TOKEN
+            - name: DISCORD_ALLOWED_USERS
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: DISCORD_ALLOWED_USERS
           ports:
             - name: http
               containerPort: 9119

--- a/cluster/apps/default/hermes-agent/templates/externalsecret.yaml
+++ b/cluster/apps/default/hermes-agent/templates/externalsecret.yaml
@@ -27,3 +27,9 @@ spec:
     - secretKey: SIGNAL_HOME_CHANNEL
       remoteRef:
         key: "398a8c7d-403f-4f06-b441-b45600aa8c7f" #gitleaks:allow #HERMES_SIGNAL_HOME_CHANNEL
+    - secretKey: DISCORD_BOT_TOKEN
+      remoteRef:
+        key: "be7ed9dc-3301-4c8b-adcd-b45600ea8816" #gitleaks:allow #HERMES_DISCORD_BOT_TOKEN
+    - secretKey: DISCORD_ALLOWED_USERS
+      remoteRef:
+        key: "17384da9-0339-44a9-b322-b45600eaaf2b" #gitleaks:allow #HERMES_DISCORD_ALLOWED_USERS

--- a/docs/superpowers/plans/2026-05-26-hermes-agent-discord.md
+++ b/docs/superpowers/plans/2026-05-26-hermes-agent-discord.md
@@ -1,0 +1,135 @@
+# Hermes Agent Discord Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Discord as a messaging channel for hermes-agent by wiring two Bitwarden secrets into the existing ExternalSecret and injecting them as env vars on the hermes-agent container.
+
+**Architecture:** No new containers or services — Discord runs in-process inside the hermes-agent gateway. Two existing manifest files are modified: `externalsecret.yaml` gets two new Bitwarden secret refs, and `deployment.yaml` gets two new env vars that read from the resulting K8s Secret.
+
+**Tech Stack:** Helm, Kubernetes ExternalSecret (ESO), Bitwarden Secrets Manager
+
+---
+
+## Prerequisites (manual steps before coding)
+
+These are human actions, not code tasks. Complete them before starting Task 1.
+
+- [ ] In the Discord Developer Portal, create a bot application and collect the bot token (see spec: `docs/superpowers/specs/2026-05-26-hermes-agent-discord-design.md` — "How to Create and Configure the Discord Bot").
+- [ ] Enable **Server Members Intent** and **Message Content Intent** in the Bot tab.
+- [ ] Collect the comma-separated Discord user IDs for `DISCORD_ALLOWED_USERS`.
+- [ ] Create two secrets in Bitwarden Secrets Manager and note their UUIDs:
+  - `HERMES_DISCORD_BOT_TOKEN` → the bot token string
+  - `HERMES_DISCORD_ALLOWED_USERS` → comma-separated user IDs
+- [ ] Invite the bot to your Discord server via the OAuth2 URL with the required permissions.
+
+---
+
+### Task 1: Add Discord secrets to ExternalSecret
+
+**Files:**
+- Modify: `cluster/apps/default/hermes-agent/templates/externalsecret.yaml`
+
+- [ ] **Step 1: Add two secret entries to externalsecret.yaml**
+
+  Open `cluster/apps/default/hermes-agent/templates/externalsecret.yaml`. After the existing `SIGNAL_HOME_CHANNEL` entry (line 29), add:
+
+  ```yaml
+      - secretKey: DISCORD_BOT_TOKEN
+        remoteRef:
+          key: "<BITWARDEN_UUID_BOT_TOKEN>" #gitleaks:allow #HERMES_DISCORD_BOT_TOKEN
+      - secretKey: DISCORD_ALLOWED_USERS
+        remoteRef:
+          key: "<BITWARDEN_UUID_ALLOWED_USERS>" #gitleaks:allow #HERMES_DISCORD_ALLOWED_USERS
+  ```
+
+  Replace `<BITWARDEN_UUID_BOT_TOKEN>` and `<BITWARDEN_UUID_ALLOWED_USERS>` with the actual UUIDs from Bitwarden.
+
+- [ ] **Step 2: Render to verify the template is valid**
+
+  ```bash
+  cd cluster/apps/default/hermes-agent
+  helm template hermes-agent . -f values.yaml
+  ```
+
+  Expected: full manifest output with no errors. Verify the ExternalSecret contains both new `secretKey` entries.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add cluster/apps/default/hermes-agent/templates/externalsecret.yaml
+  git commit -m "feat(hermes-agent): add Discord secrets to ExternalSecret"
+  ```
+
+---
+
+### Task 2: Inject Discord env vars into the deployment
+
+**Files:**
+- Modify: `cluster/apps/default/hermes-agent/templates/deployment.yaml`
+
+- [ ] **Step 1: Add env vars to the hermes-agent container**
+
+  Open `cluster/apps/default/hermes-agent/templates/deployment.yaml`. After the `SIGNAL_HOME_CHANNEL` env var block (around line 98), add:
+
+  ```yaml
+            - name: DISCORD_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: DISCORD_BOT_TOKEN
+            - name: DISCORD_ALLOWED_USERS
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-secrets
+                  key: DISCORD_ALLOWED_USERS
+  ```
+
+  Maintain the same 12-space indentation as the surrounding env var entries.
+
+- [ ] **Step 2: Render and inspect the deployment manifest**
+
+  ```bash
+  cd cluster/apps/default/hermes-agent
+  helm template hermes-agent . -f values.yaml
+  ```
+
+  Expected: no errors. In the rendered Deployment, confirm the `hermes-agent` container env list includes both `DISCORD_BOT_TOKEN` and `DISCORD_ALLOWED_USERS` with `secretKeyRef.name: hermes-agent-secrets`.
+
+- [ ] **Step 3: Run full lint**
+
+  ```bash
+  cd /workspaces/home-ops
+  task lint:all
+  ```
+
+  Expected: all checks pass (yamllint, helmlint, prettier).
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add cluster/apps/default/hermes-agent/templates/deployment.yaml
+  git commit -m "feat(hermes-agent): inject Discord env vars into hermes-agent container"
+  ```
+
+---
+
+### Task 3: Open PR
+
+- [ ] **Step 1: Push branch and open PR**
+
+  ```bash
+  git push -u origin HEAD
+  gh pr create \
+    --title "feat(hermes-agent): add Discord integration" \
+    --body "Adds DISCORD_BOT_TOKEN and DISCORD_ALLOWED_USERS to the hermes-agent ExternalSecret and deployment env vars. No new containers required — Discord runs in-process. Spec: docs/superpowers/specs/2026-05-26-hermes-agent-discord-design.md"
+  ```
+
+- [ ] **Step 2: After merge, verify in ArgoCD**
+
+  Confirm ArgoCD syncs the `hermes-agent` app successfully. Check the hermes-agent pod logs for Discord gateway startup:
+
+  ```bash
+  kubectl logs -n hermes-agent deploy/hermes-agent | grep -i discord
+  ```
+
+  Expected: log lines indicating the Discord gateway connected (no auth errors).

--- a/docs/superpowers/specs/2026-05-26-hermes-agent-discord-design.md
+++ b/docs/superpowers/specs/2026-05-26-hermes-agent-discord-design.md
@@ -1,0 +1,131 @@
+# Hermes Agent — Discord Integration Design
+
+**Date:** 2026-05-26  
+**Status:** Approved
+
+## Goal
+
+Add Discord as a second messaging channel for the hermes-agent, alongside the existing Signal integration. The bot token and allowed-users list are stored in Bitwarden and injected as env vars; all other Discord settings use hermes-agent defaults.
+
+## Architecture
+
+No new containers or services. Discord runs inside the existing `hermes-agent` gateway process. Two changes to existing manifests:
+
+- `externalsecret.yaml` — two new Bitwarden secret references
+- `deployment.yaml` — two new env vars on the `hermes-agent` container
+
+## Changes
+
+### externalsecret.yaml
+
+Add under `spec.data`:
+
+```yaml
+- secretKey: DISCORD_BOT_TOKEN
+  remoteRef:
+    key: "<BITWARDEN_UUID>" #gitleaks:allow #HERMES_DISCORD_BOT_TOKEN
+- secretKey: DISCORD_ALLOWED_USERS
+  remoteRef:
+    key: "<BITWARDEN_UUID>" #gitleaks:allow #HERMES_DISCORD_ALLOWED_USERS
+```
+
+### deployment.yaml
+
+Add to the `hermes-agent` container `env` list:
+
+```yaml
+- name: DISCORD_BOT_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: hermes-agent-secrets
+      key: DISCORD_BOT_TOKEN
+- name: DISCORD_ALLOWED_USERS
+  valueFrom:
+    secretKeyRef:
+      name: hermes-agent-secrets
+      key: DISCORD_ALLOWED_USERS
+```
+
+## Default Behavior
+
+With only these two env vars set, hermes-agent applies these Discord defaults:
+
+| Setting | Default | Meaning |
+|---|---|---|
+| `require_mention` | `true` | Bot only responds when @mentioned in server channels |
+| `auto_thread` | `true` | Creates a thread on each @mention |
+| `history_backfill` | `true` | Recovers missed messages on mention |
+| `allow_mentions.everyone` | `false` | Blocks @everyone/@here pings |
+| `allow_mentions.users` | `true` | Allows @user pings |
+
+DMs to the bot always work regardless of `require_mention`.
+
+---
+
+## How to Create and Configure the Discord Bot
+
+### 1. Create an Application
+
+1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
+2. Click **New Application**, give it a name (e.g. `hermes`)
+3. Under **Bot** tab: click **Add Bot**
+4. Set **Public Bot** to ON if you want others to invite it; OFF for personal use
+
+### 2. Enable Privileged Gateway Intents
+
+Still under the **Bot** tab, enable both:
+
+- **Server Members Intent** — required for username resolution
+- **Message Content Intent** — **critical**: without this the bot receives message events but the message text is empty
+
+### 3. Get the Bot Token
+
+Under **Bot** tab → **Token** → click **Reset Token**.  
+Copy the token — you will store this as `DISCORD_BOT_TOKEN` in Bitwarden.
+
+### 4. Set Required Permissions
+
+When generating the invite URL (see step 6), grant at minimum:
+
+- View Channels
+- Send Messages
+- Read Message History
+- Attach Files
+- Embed Links
+- Send Messages in Threads
+- Add Reactions
+
+### 5. Collect Allowed User IDs
+
+To find a user's Discord ID: in Discord, enable **Developer Mode** (User Settings → Advanced → Developer Mode), then right-click any user → **Copy User ID**.
+
+The value for `DISCORD_ALLOWED_USERS` is a comma-separated list of these IDs, e.g. `123456789012345678,987654321098765432`.
+
+### 6. Invite the Bot to Your Server
+
+Go to **Installation** tab in the Developer Portal, or build the URL manually:
+
+```
+https://discord.com/api/oauth2/authorize?client_id=<YOUR_APP_ID>&permissions=<PERMISSIONS_INT>&scope=bot
+```
+
+Open the URL and select the target server.
+
+### 7. Store Secrets in Bitwarden
+
+Create two secrets in Bitwarden Secrets Manager:
+
+| Secret name | Value |
+|---|---|
+| `HERMES_DISCORD_BOT_TOKEN` | The bot token from step 3 |
+| `HERMES_DISCORD_ALLOWED_USERS` | Comma-separated user IDs from step 5 |
+
+Note the UUIDs for each — you will substitute them into `externalsecret.yaml`.
+
+---
+
+## Out of Scope
+
+- `DISCORD_HOME_CHANNEL` — not added; can be added later if proactive notifications are needed
+- `DISCORD_ALLOWED_ROLES` — not added; individual user IDs are sufficient for now
+- `discord:` configmap section — defaults are acceptable; add only when a setting needs changing


### PR DESCRIPTION
## Summary

- Add `DISCORD_BOT_TOKEN` and `DISCORD_ALLOWED_USERS` to the hermes-agent `ExternalSecret`, pulling from Bitwarden Secrets Manager
- Inject both values as env vars into the `hermes-agent` container via `secretKeyRef`
- No new containers or services — Discord runs in-process inside the hermes-agent gateway

## Test Plan

- [ ] ArgoCD syncs `hermes-agent` app successfully after merge
- [ ] `kubectl logs -n hermes-agent deploy/hermes-agent | grep -i discord` shows Discord gateway connected (no auth errors)
- [ ] Discord bot responds to @mentions in server channels (default `require_mention: true`)
- [ ] DMs to the bot work

## Notes

Spec: `docs/superpowers/specs/2026-05-26-hermes-agent-discord-design.md`
Bot setup guide included in spec (Developer Portal steps, required intents, permissions).