### PR TITLE
feat(honcho): add self-hosted Honcho memory server and wire hermes-agent

### DIFF
--- a/.plans/honcho-integration/plan.md
+++ b/.plans/honcho-integration/plan.md
@@ -1,0 +1,132 @@
+# Honcho Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy a self-hosted Honcho memory server and wire hermes-agent to use it as a persistent cross-session memory provider across all 7 Hermes profiles.
+
+**Architecture:** New `cluster/apps/default/honcho/` Helm chart deploys Honcho API + Deriver as two Deployments, backed by CloudNativePG (pgvector-enabled standard image) in the `honcho` namespace. Hermes-agent gains `memory.provider: honcho` via the existing config-seeder, plus a new `honcho-seeder` init-container that deep-merges `honcho.json` onto the data PVC at `/opt/data/.hermes/honcho.json`.
+
+**Tech Stack:** `ghcr.io/plastic-labs/honcho:v3.0.7` (GHCR published), CNPG `ghcr.io/cloudnative-pg/postgresql:17.6-standard-bookworm` (bundles pgvector), ESO + Bitwarden for secrets, existing `charts/pgsql-cnpg` subchart, OpenRouter via `LLM_OPENAI_API_KEY`.
+
+---
+
+## Phase 0 Research Summary
+
+### Honcho server
+
+- **Image**: `ghcr.io/plastic-labs/honcho:v3.0.7` on GHCR ✅
+- **API container**: command `["sh", "docker/entrypoint.sh"]` → runs `scripts/provision_db.py` (alembic migrations) then starts FastAPI. Migrations are idempotent; run on every API restart.
+- **Deriver container**: command `["/app/.venv/bin/python", "-m", "src.deriver"]` — background reasoning worker, separate Deployment.
+- **DB**: PostgreSQL + pgvector mandatory (vector search). Use CNPG standard image `17.6-standard-bookworm` + `bootstrap.initdb.postInitApplicationSQL: ["CREATE EXTENSION IF NOT EXISTS vector"]`.
+- **Redis**: Optional. Start with `CACHE_ENABLED=false`.
+- **Migrations**: Handled by `docker/entrypoint.sh` before API starts (no separate Job needed).
+
+### Database connection string
+
+- CNPG creates k8s Secret `honchodb-cnpg-app` with `username` and `password` (alphanumeric, URL-safe).
+- Use Kubernetes dependent env vars to build `DB_CONNECTION_URI`:
+  ```
+  DB_USER  ← secretKeyRef honchodb-cnpg-app/username
+  DB_PASS  ← secretKeyRef honchodb-cnpg-app/password
+  DB_CONNECTION_URI = "postgresql+psycopg://$(DB_USER):$(DB_PASS)@honchodb-cnpg-rw.honcho.svc.cluster.local:5432/app"
+  ```
+
+### LLM provider: OpenRouter (new dedicated key)
+
+- New Bitwarden entry for OpenRouter key (separate from hermes-agent's key, for usage tracking).
+- No global base URL env var in Honcho — must set `*__OVERRIDES__BASE_URL` per module.
+- Modules: DERIVER, SUMMARY, EMBEDDING, 5 DIALECTIC levels (`DIALECTIC_LEVELS__{level}__MODEL_CONFIG__*`), DREAM (deduction + induction) = 10 modules × 3 env vars each.
+- Models to use via OpenRouter (all `transport: openai`):
+
+| Module                | Model                           | Reasoning                           |
+| --------------------- | ------------------------------- | ----------------------------------- |
+| DERIVER               | `google/gemini-flash-1.5`       | Cheap background worker             |
+| SUMMARY               | `google/gemini-flash-1.5`       | Cheap summarisation                 |
+| EMBEDDING             | `openai/text-embedding-3-small` | Standard embeddings via OpenRouter  |
+| DIALECTIC minimal/low | `google/gemini-flash-1.5`       | Cost-efficient (default level used) |
+| DIALECTIC medium      | `google/gemini-2.0-flash`       | Moderate quality                    |
+| DIALECTIC high        | `anthropic/claude-3-5-haiku`    | High quality                        |
+| DIALECTIC max         | `anthropic/claude-3-5-sonnet`   | Maximum quality                     |
+| DREAM deduction       | `google/gemini-flash-1.5`       | Background consolidation            |
+| DREAM induction       | `google/gemini-flash-1.5`       | Background consolidation            |
+
+### hermes-agent profiles
+
+Profiles are **imperative/stateful** (NOT declared in Helm). From README: `default`, `orchestrator`, `devops`, `researcher`, `dotnet-dev`, `node-dev`, `mobile-dev`.
+
+Honcho host key mapping:
+
+- `default` → `"hermes"` (aiPeer: `"hermes"`)
+- `orchestrator` → `"hermes.orchestrator"` (aiPeer: `"orchestrator"`)
+- `devops` → `"hermes.devops"` (aiPeer: `"devops"`)
+- `researcher` → `"hermes.researcher"` (aiPeer: `"researcher"`)
+- `dotnet-dev` → `"hermes.dotnet-dev"` (aiPeer: `"dotnet-dev"`)
+- `node-dev` → `"hermes.node-dev"` (aiPeer: `"node-dev"`)
+- `mobile-dev` → `"hermes.mobile-dev"` (aiPeer: `"mobile-dev"`)
+
+### honcho.json delivery
+
+- Target path: `/opt/data/.hermes/honcho.json` (on PVC `hermes-agent-data`)
+- Strategy: **deep-merge** (ConfigMap overrides propagate; runtime additions from `hermes honcho sync` are preserved across restarts)
+- Init-container `honcho-seeder`: uses hermes-agent image (has Python 3), runs a JSON deep-merge script identical in shape to the existing `config-seeder`
+
+### S3 backup: enabled
+
+Same S3 bucket and credentials as litellm (`k8s-at-home-backup`). Reuse same Bitwarden entries:
+
+- `S3_ACCESS_KEY_ID`: `e00e1e38-ae37-479a-8b46-b409016331eb`
+- `S3_ACCESS_SECRET_KEY`: `4d5a418c-82ed-4b8e-bfbf-b40901634ea4`
+
+---
+
+## File Map
+
+### New: `cluster/apps/default/honcho/`
+
+| File                                | Purpose                                                                               |
+| ----------------------------------- | ------------------------------------------------------------------------------------- |
+| `app-config.yaml`                   | ArgoCD ApplicationSet config, `namespace: honcho`, `SECRET_PROVIDER: cluster-secrets` |
+| `Chart.yaml`                        | Local chart with `pgsql-cnpg` v1.2.0 dependency                                       |
+| `values.yaml`                       | Image tag, resources, LLM env config, CNPG + S3 backup                                |
+| `templates/externalsecret.yaml`     | `honcho-secrets`: OpenRouter key + S3 creds from Bitwarden                            |
+| `templates/deployment-api.yaml`     | Honcho API Deployment                                                                 |
+| `templates/deployment-deriver.yaml` | Honcho Deriver Deployment                                                             |
+| `templates/service.yaml`            | ClusterIP Service port 8000                                                           |
+
+### Modified: `cluster/apps/default/hermes-agent/values.yaml`
+
+Add `memory.provider: honcho` under `hermes.config:`.
+
+### New: `cluster/apps/default/hermes-agent/templates/honcho-configmap.yaml`
+
+ConfigMap `hermes-agent-honcho` containing `honcho.json` with all 7 profile host blocks and tuning settings.
+
+### Modified: `cluster/apps/default/hermes-agent/templates/deployment.yaml`
+
+Add `honcho-seeder` init-container (after `config-seeder`) + `honcho-config` volume.
+
+---
+
+## Architecture Decisions
+
+| Decision           | Choice                                       | Reason                                                                        |
+| ------------------ | -------------------------------------------- | ----------------------------------------------------------------------------- |
+| Two Deployments    | api + deriver                                | Different commands, restart policies                                          |
+| pgvector           | CNPG standard image + postInitApplicationSQL | No custom image needed                                                        |
+| Migrations         | Via entrypoint.sh on every API start         | Idempotent, matches upstream docker-compose                                   |
+| Connection string  | K8s dependent env vars                       | Simple, CNPG passwords are alphanumeric                                       |
+| Redis              | Disabled initially                           | Reduces deployment scope; can be added if latency is visible                  |
+| LLM provider       | OpenRouter (new key)                         | Reuse OpenRouter account; separate key = isolated billing                     |
+| honcho.json seeder | Deep-merge (Python in hermes-agent image)    | Preserves `hermes honcho sync` additions; ConfigMap values stay authoritative |
+| Auth               | `AUTH_USE_AUTH=false`                        | ClusterIP only, never exposed outside cluster                                 |
+| All 7 profiles     | Declared in initial honcho.json              | Avoids manual `hermes honcho sync` step; profiles match README                |
+
+## Risks
+
+| Risk                                          | Mitigation                                                                                                                             |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `honcho-ai` lazy-install fails on pod restart | Reinstalls on first use from PyPI (intended behavior per upstream). Monitor `hermes honcho status`.                                    |
+| CNPG pgvector extension not found             | Standard image bundles pgvector; check CNPG pod logs if extension fails.                                                               |
+| Deriver starts before DB is ready             | Deriver retries automatically; no ordering dependency needed.                                                                          |
+| OpenRouter model names change                 | Pin exact model strings; update values.yaml if a model is deprecated.                                                                  |
+| Embeddings not available via OpenRouter       | If `text-embedding-3-small` is unavailable via OpenRouter, add `LLM_OPENAI_API_KEY` pointing to real OpenAI for EMBEDDING module only. |

--- a/.plans/honcho-integration/tasks.md
+++ b/.plans/honcho-integration/tasks.md
@@ -1,0 +1,572 @@
+# Honcho Integration — Tasks
+
+> Self-contained checklist. Executable without reading plan.md.
+> REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans.
+
+## Prerequisites (manual, done before starting tasks)
+
+- [ ] **P1**: Create feature branch: `git checkout -b feat/honcho-integration`
+- [ ] **P2**: Add new OpenRouter API key to Bitwarden Secrets Manager (separate key for Honcho, distinct from hermes-agent's key) → note the `bwsId`
+
+---
+
+## Phase 1: Honcho Server
+
+### Task 1.1: Chart scaffolding
+
+- [ ] Create `cluster/apps/default/honcho/app-config.yaml`:
+
+```yaml
+- enabled: "true"
+  namespace: honcho
+  syncPolicy:
+    enabled: true
+    selfHeal: true
+    prune: false
+  plugin:
+    env:
+      - name: SECRET_PROVIDER
+        value: cluster-secrets
+```
+
+- [ ] Create `cluster/apps/default/honcho/Chart.yaml`:
+
+```yaml
+apiVersion: v2
+name: honcho
+type: application
+version: 1.0.0
+dependencies:
+  - name: pgsql-cnpg
+    version: 1.2.0
+    repository: file://../../../../charts/pgsql-cnpg/
+```
+
+- [ ] Run: `helm dependency update cluster/apps/default/honcho/`
+- [ ] Verify: `ls cluster/apps/default/honcho/Chart.lock` — file must exist.
+
+---
+
+### Task 1.2: ExternalSecret
+
+- [ ] Create `cluster/apps/default/honcho/templates/externalsecret.yaml`:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: honcho-secrets
+  namespace: honcho
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  refreshInterval: 1h
+  target:
+    name: honcho-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: HONCHO_OPENROUTER_API_KEY
+      remoteRef:
+        key: {{.Values.openrouterBwsId | quote}}
+    - secretKey: S3_ACCESS_KEY_ID
+      remoteRef:
+        key: "e00e1e38-ae37-479a-8b46-b409016331eb" #gitleaks:allow #S3_ACCESS_KEY
+    - secretKey: S3_ACCESS_SECRET_KEY
+      remoteRef:
+        key: "4d5a418c-82ed-4b8e-bfbf-b40901634ea4" #gitleaks:allow #S3_SECRET_KEY
+```
+
+---
+
+### Task 1.3: values.yaml
+
+- [ ] Create `cluster/apps/default/honcho/values.yaml`. Replace `<REPLACE>` with actual OpenRouter Bitwarden ID from prerequisite P2:
+
+```yaml
+honcho:
+  image:
+    repository: ghcr.io/plastic-labs/honcho
+    tag: "v3.0.7"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+  deriver:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
+openrouterBwsId: "<REPLACE: bwsId of Honcho OpenRouter key in Bitwarden>" #gitleaks:allow
+
+pgsql-cnpg:
+  name: honchodb
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.6-standard-bookworm
+  instances: 2
+  storage:
+    size: 5Gi
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 100m
+    limits:
+      memory: 512Mi
+      cpu: 500m
+  bootstrap:
+    initdb:
+      postInitApplicationSQL:
+        - CREATE EXTENSION IF NOT EXISTS vector
+  monitoring:
+    enablePodMonitor: true
+  backup:
+    retentionPolicy: "10d"
+    barmanObjectStore:
+      destinationPath: "s3://k8s-at-home-backup/cnpg/honcho"
+      endpointURL: <secret:s3_endpoint>
+      s3Credentials:
+        accessKeyId:
+          name: honcho-secrets
+          key: S3_ACCESS_KEY_ID
+        secretAccessKey:
+          name: honcho-secrets
+          key: S3_ACCESS_SECRET_KEY
+  scheduledBackups:
+    - name: honchodb-cnpg-backup
+      spec:
+        immediate: true
+        schedule: "10 0 0 * * *"
+        backupOwnerReference: self
+```
+
+---
+
+### Task 1.4: Shared env helper (configmap for LLM config)
+
+The deployment templates reference a shared env list. Define it as a Helm helper to avoid duplication between API and Deriver.
+
+- [ ] Create `cluster/apps/default/honcho/templates/_helpers.tpl`:
+
+```
+{{- define "honcho.llmEnv" -}}
+- name: DB_USER
+  valueFrom:
+    secretKeyRef:
+      name: honchodb-cnpg-app
+      key: username
+- name: DB_PASS
+  valueFrom:
+    secretKeyRef:
+      name: honchodb-cnpg-app
+      key: password
+- name: DB_CONNECTION_URI
+  value: "postgresql+psycopg://$(DB_USER):$(DB_PASS)@honchodb-cnpg-rw.honcho.svc.cluster.local:5432/app"
+- name: AUTH_USE_AUTH
+  value: "false"
+- name: SENTRY_ENABLED
+  value: "false"
+- name: CACHE_ENABLED
+  value: "false"
+- name: LLM_OPENAI_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: honcho-secrets
+      key: HONCHO_OPENROUTER_API_KEY
+# DERIVER
+- name: DERIVER_MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DERIVER_MODEL_CONFIG__MODEL
+  value: google/gemini-flash-1.5
+- name: DERIVER_MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+# SUMMARY
+- name: SUMMARY_MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: SUMMARY_MODEL_CONFIG__MODEL
+  value: google/gemini-flash-1.5
+- name: SUMMARY_MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+# EMBEDDING
+- name: EMBEDDING_MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: EMBEDDING_MODEL_CONFIG__MODEL
+  value: openai/text-embedding-3-small
+- name: EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+# DIALECTIC levels
+- name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL
+  value: google/gemini-flash-1.5
+- name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL
+  value: google/gemini-flash-1.5
+- name: DIALECTIC_LEVELS__low__MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DIALECTIC_LEVELS__medium__MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DIALECTIC_LEVELS__medium__MODEL_CONFIG__MODEL
+  value: google/gemini-2.0-flash
+- name: DIALECTIC_LEVELS__medium__MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DIALECTIC_LEVELS__high__MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DIALECTIC_LEVELS__high__MODEL_CONFIG__MODEL
+  value: anthropic/claude-3-5-haiku
+- name: DIALECTIC_LEVELS__high__MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DIALECTIC_LEVELS__max__MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DIALECTIC_LEVELS__max__MODEL_CONFIG__MODEL
+  value: anthropic/claude-3-5-sonnet
+- name: DIALECTIC_LEVELS__max__MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+# DREAM
+- name: DREAM_DEDUCTION_MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DREAM_DEDUCTION_MODEL_CONFIG__MODEL
+  value: google/gemini-flash-1.5
+- name: DREAM_DEDUCTION_MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DREAM_INDUCTION_MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DREAM_INDUCTION_MODEL_CONFIG__MODEL
+  value: google/gemini-flash-1.5
+- name: DREAM_INDUCTION_MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+{{- end -}}
+```
+
+---
+
+### Task 1.5: API Deployment
+
+- [ ] Confirm the Honcho health endpoint: `curl -s https://raw.githubusercontent.com/plastic-labs/honcho/main/src/main.py | grep -i health` — expected `/healthcheck`.
+
+- [ ] Create `cluster/apps/default/honcho/templates/deployment-api.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: honcho-api
+  namespace: honcho
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: honcho-api
+  template:
+    metadata:
+      labels:
+        app: honcho-api
+    spec:
+      containers:
+        - name: honcho-api
+          image: "{{ .Values.honcho.image.repository }}:{{ .Values.honcho.image.tag }}"
+          command: ["sh", "docker/entrypoint.sh"]
+          env: {{- include "honcho.llmEnv" . | nindent 12}}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+          resources: {{toYaml .Values.honcho.resources | nindent 12}}
+```
+
+---
+
+### Task 1.6: Deriver Deployment
+
+- [ ] Create `cluster/apps/default/honcho/templates/deployment-deriver.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: honcho-deriver
+  namespace: honcho
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: honcho-deriver
+  template:
+    metadata:
+      labels:
+        app: honcho-deriver
+    spec:
+      containers:
+        - name: honcho-deriver
+          image: "{{ .Values.honcho.image.repository }}:{{ .Values.honcho.image.tag }}"
+          command: ["/app/.venv/bin/python", "-m", "src.deriver"]
+          env: {{- include "honcho.llmEnv" . | nindent 12}}
+          resources: {{toYaml .Values.honcho.deriver.resources | nindent 12}}
+```
+
+---
+
+### Task 1.7: Service
+
+- [ ] Create `cluster/apps/default/honcho/templates/service.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: honcho
+  namespace: honcho
+spec:
+  type: ClusterIP
+  selector:
+    app: honcho-api
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+      protocol: TCP
+```
+
+---
+
+### Task 1.8: Render and lint
+
+- [ ] Run: `helm template honcho cluster/apps/default/honcho/ -f cluster/apps/default/honcho/values.yaml`
+  - Expected output: CNPG Cluster (with `vector` postInitApplicationSQL), ScheduledBackup, ExternalSecret `honcho-secrets`, Deployments `honcho-api` and `honcho-deriver`, Service `honcho`.
+  - Verify `DB_CONNECTION_URI` env var renders with `postgresql+psycopg://` prefix.
+  - Verify all `DIALECTIC_LEVELS__*` env vars appear in both Deployments.
+
+- [ ] Run: `task lint:all` — no errors.
+
+- [ ] Commit: `git add cluster/apps/default/honcho/ && git commit -m "feat(honcho): add self-hosted Honcho server with CNPG/pgvector and OpenRouter"`
+
+---
+
+## Phase 2: Hermes-agent wiring
+
+### Task 2.1: Memory provider in hermes config
+
+- [ ] In `cluster/apps/default/hermes-agent/values.yaml`, add `memory.provider: honcho` under the existing `hermes.config:` block:
+
+```yaml
+hermes:
+  config:
+    # ...existing fields unchanged...
+    memory:
+      provider: honcho
+```
+
+(The config-seeder deep-merges this into `/opt/data/config.yaml` on every pod start.)
+
+---
+
+### Task 2.2: honcho.json ConfigMap
+
+- [ ] Create `cluster/apps/default/hermes-agent/templates/honcho-configmap.yaml`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-agent-honcho
+  namespace: hermes-agent
+data:
+  honcho.json: |
+    {
+      "baseUrl": "http://honcho.honcho.svc.cluster.local:8000",
+      "observationMode": "directional",
+      "recallMode": "hybrid",
+      "sessionStrategy": "per-session",
+      "contextCadence": 1,
+      "dialecticCadence": 2,
+      "dialecticDepth": 1,
+      "hosts": {
+        "hermes": {
+          "enabled": true,
+          "aiPeer": "hermes",
+          "peerName": "mmalyska",
+          "workspace": "hermes"
+        },
+        "hermes.orchestrator": {
+          "enabled": true,
+          "aiPeer": "orchestrator",
+          "peerName": "mmalyska",
+          "workspace": "hermes"
+        },
+        "hermes.devops": {
+          "enabled": true,
+          "aiPeer": "devops",
+          "peerName": "mmalyska",
+          "workspace": "hermes"
+        },
+        "hermes.researcher": {
+          "enabled": true,
+          "aiPeer": "researcher",
+          "peerName": "mmalyska",
+          "workspace": "hermes"
+        },
+        "hermes.dotnet-dev": {
+          "enabled": true,
+          "aiPeer": "dotnet-dev",
+          "peerName": "mmalyska",
+          "workspace": "hermes"
+        },
+        "hermes.node-dev": {
+          "enabled": true,
+          "aiPeer": "node-dev",
+          "peerName": "mmalyska",
+          "workspace": "hermes"
+        },
+        "hermes.mobile-dev": {
+          "enabled": true,
+          "aiPeer": "mobile-dev",
+          "peerName": "mmalyska",
+          "workspace": "hermes"
+        }
+      }
+    }
+```
+
+---
+
+### Task 2.3: honcho-seeder init-container
+
+- [ ] In `cluster/apps/default/hermes-agent/templates/deployment.yaml`, add the `honcho-seeder` init-container **after** the existing `config-seeder`:
+
+```yaml
+- name: honcho-seeder
+  image: "{{ .Values.hermes.image.repository }}:{{ .Values.hermes.image.tag }}"
+  command:
+    - python3
+    - -c
+    - |
+      import json, os
+
+      template_path = '/honcho-config/honcho.json'
+      target_path = '/opt/data/.hermes/honcho.json'
+
+      with open(template_path) as f:
+          overrides = json.load(f)
+
+      os.makedirs(os.path.dirname(target_path), exist_ok=True)
+
+      if os.path.exists(target_path):
+          with open(target_path) as f:
+              config = json.load(f) or {}
+
+          def deep_merge(base, src):
+              for k, v in src.items():
+                  if isinstance(v, dict) and isinstance(base.get(k), dict):
+                      deep_merge(base[k], v)
+                  else:
+                      base[k] = v
+
+          deep_merge(config, overrides)
+      else:
+          config = overrides
+
+      with open(target_path, 'w') as f:
+          json.dump(config, f, indent=2)
+
+  volumeMounts:
+    - name: data
+      mountPath: /opt/data
+    - name: honcho-config
+      mountPath: /honcho-config
+```
+
+- [ ] In the same file, under `volumes:`, add:
+
+```yaml
+- name: honcho-config
+  configMap:
+    name: hermes-agent-honcho
+```
+
+---
+
+### Task 2.4: Render and lint
+
+- [ ] Run: `helm template hermes-agent cluster/apps/default/hermes-agent/ -f cluster/apps/default/hermes-agent/values.yaml`
+  - Verify `honcho-seeder` init-container appears in Pod spec after `config-seeder`.
+  - Verify `honcho-config` volume and mount appear.
+  - Verify `memory.provider: honcho` appears in the rendered `hermes-agent-config` ConfigMap.
+
+- [ ] Run: `task lint:all` — no errors.
+
+- [ ] Commit: `git add cluster/apps/default/hermes-agent/ && git commit -m "feat(hermes-agent): wire Honcho as memory provider with deep-merge seeder"`
+
+---
+
+## Phase 3: Open PR
+
+- [ ] Push branch: `git push -u origin feat/honcho-integration`
+- [ ] Open PR with description covering: what's changed, ArgoCD sync order (Honcho first, then hermes-agent restart), rollback steps.
+
+---
+
+## Phase 4: Post-deploy validation
+
+After ArgoCD syncs (Honcho app first; hermes-agent restarts after):
+
+### Honcho healthy
+
+- [ ] `kubectl -n honcho get pods` — all pods Running: `honcho-api-*`, `honcho-deriver-*`, `honchodb-cnpg-1`, `honchodb-cnpg-2`.
+- [ ] API responds: `kubectl -n honcho exec deploy/honcho-api -- curl -s http://localhost:8000/healthcheck` — HTTP 200.
+
+### pgvector active
+
+- [ ] `kubectl -n honcho exec honchodb-cnpg-1 -- psql -U app app -c "SELECT extname FROM pg_extension WHERE extname='vector';"` — returns `vector`.
+
+### honcho.json placed correctly
+
+- [ ] `kubectl -n hermes-agent exec deploy/hermes-agent -c hermes-agent -- cat /opt/data/.hermes/honcho.json` — file present, `baseUrl` shows `http://honcho.honcho.svc.cluster.local:8000`, 7 host blocks visible.
+
+### Hermes sees the provider
+
+- [ ] In Discord/Signal, send `hermes honcho status` — expected: connected, shows baseUrl and host list.
+
+### Memory roundtrip
+
+- [ ] Start a conversation with the `default` profile (via Discord or Signal). Share a specific preference, e.g. "I always prefer dark mode in UIs."
+- [ ] Start a new session (new conversation). Ask Hermes: "What do you know about my UI preferences?" — Honcho should surface the stored fact via dialectic or context injection.
+
+### Profile isolation check
+
+- [ ] Start a conversation with a worker profile (e.g., `devops`). Ask it to recall the UI preference. The `devops` aiPeer has its own memory but shares the user peer (`mmalyska`) — it should see the stored user fact if sharing is configured, or return empty if isolated.
+
+### Rollback procedure
+
+- **Disable memory provider only**: Remove `memory.provider: honcho` from `hermes-agent/values.yaml` → ArgoCD sync → hermes-agent restarts without memory. Honcho server untouched (no data loss).
+- **Disable Honcho entirely**: Set `enabled: "false"` in `cluster/apps/default/honcho/app-config.yaml` → ArgoCD sync removes Honcho app. CNPG PVC survives for later restore.
+- **Full rollback**: Revert both commits on the branch and close the PR.
+
+---
+
+## Phase 5: Follow-up (after stable)
+
+- [ ] Pin Honcho image to SHA digest for Renovate tracking.
+- [ ] Evaluate cost: check OpenRouter billing for `honcho` key after 1 week.
+- [ ] Consider `dialecticDepth: 2` if memory quality seems shallow.
+- [ ] Consider enabling Redis if Honcho query latency is noticeable (>200ms).
+- [ ] Add volsync backup for Honcho namespace if the CNPG PVC isn't covered.

--- a/.plans/list.md
+++ b/.plans/list.md
@@ -1,5 +1,6 @@
 # Active Plans
 
-| Plan | Description | Started |
-|------|-------------|---------|
-| [hermes-agent-discord](../docs/superpowers/plans/2026-05-26-hermes-agent-discord.md) | Add Discord messaging channel to hermes-agent | 2026-05-26 |
+| Plan                                                                                 | Description                                                      | Started    |
+| ------------------------------------------------------------------------------------ | ---------------------------------------------------------------- | ---------- |
+| [hermes-agent-discord](../docs/superpowers/plans/2026-05-26-hermes-agent-discord.md) | Add Discord messaging channel to hermes-agent                    | 2026-05-26 |
+| [honcho-integration](honcho-integration/plan.md)                                     | Deploy self-hosted Honcho + wire hermes-agent as memory provider | 2026-05-29 |

--- a/cluster/apps/default/hermes-agent/README.md
+++ b/cluster/apps/default/hermes-agent/README.md
@@ -17,7 +17,11 @@ Hermes Agent deployed as a single-pod application on the home Kubernetes cluster
 │  HTTPRoute     │  PVC     │    │  PVC  │      │
 │  (envoy)       │  1Gi     │    │  1Gi  │      │
 │                └─────────┘    └───────┘      │
-└──────────────────────────────────────────────┘
+└───────────────────────┬──────────────────────┘
+                        │ memory.provider: honcho
+                        ▼
+          http://honcho.honcho.svc.cluster.local:8000
+          (namespace: honcho — see ../honcho/README.md)
 ```
 
 | Component | Purpose |
@@ -29,6 +33,7 @@ Hermes Agent deployed as a single-pod application on the home Kubernetes cluster
 | **PVC `hermes-signal-data`** | Signal CLI state (registration, key material) |
 | **VolSync** | Restic backups of both PVCs to S3 (every 6 hours) |
 | **ExternalSecret** | API keys from Bitwarden → K8s Secret → env vars in pod |
+| **Honcho** | Self-hosted memory server (separate namespace) — provides persistent cross-session user memory via Theory-of-Mind reasoning and vector recall |
 
 ## Helm Values (`values.yaml`)
 
@@ -41,7 +46,10 @@ The declarative configuration lives in `values.yaml` and covers:
 - **`externalSecrets`** — Bitwarden secret references for API keys
 - **`backup`** — VolSync schedule and retention
 
-The init container merges the ConfigMap template into the existing config.yaml on the PVC — so values changed in `values.yaml` are picked up on the next restart, while runtime state (sessions, memory, kanban board) survives on the PVC.
+Two init containers run on every pod start:
+
+1. **`config-seeder`** — deep-merges the `hermes-agent-config` ConfigMap (rendered from `values.yaml`) into `/opt/data/config.yaml` on the PVC. Values changed in `values.yaml` are picked up on next restart; runtime state (sessions, kanban board) survives on the PVC.
+2. **`honcho-seeder`** — deep-merges `hermes-agent-honcho` ConfigMap into `/opt/data/.hermes/honcho.json`. Declares all 7 Hermes profiles as Honcho memory hosts. Runtime additions made by `hermes honcho sync` are preserved across restarts (deep-merge, not overwrite).
 
 ## HTTPRoute
 
@@ -160,6 +168,48 @@ This auto-discovers all profiles and registers them as valid assignees.
 │   └── gateways/
 └── voice-memos/
 ```
+
+## Memory (Honcho)
+
+Hermes uses [Honcho](../honcho/README.md) as a persistent memory backend (`memory.provider: honcho` in `config.yaml`). Memory is scoped per-profile — each of the 7 profiles maps to a distinct Honcho host with a shared workspace.
+
+### How it works
+
+- After each conversation turn, the Honcho **deriver** extracts user facts and updates the vector store in the background.
+- On the next turn, Honcho injects relevant context from past sessions before the model responds.
+- The `dialecticCadence` (default: every 2 messages) controls how often deep recall runs; `contextCadence` (default: every message) controls context injection frequency.
+
+### honcho.json
+
+Honcho configuration lives at `/opt/data/.hermes/honcho.json` on the PVC. It is seeded on each pod start by the `honcho-seeder` init container from the `hermes-agent-honcho` ConfigMap. To change Honcho settings (e.g. `dialecticDepth`, `recallMode`), edit `templates/honcho-configmap.yaml` and restart the pod.
+
+### Useful commands
+
+```bash
+# Check memory provider status (run in Discord/Signal)
+# hermes honcho status
+
+# Sync profile host registration with Honcho server
+# hermes honcho sync
+
+# Inspect the live honcho.json on the PVC
+kubectl exec deploy/hermes-agent -n hermes-agent -c hermes-agent -- \
+  cat /opt/data/.hermes/honcho.json
+```
+
+### Profile → Honcho host mapping
+
+| Hermes profile | Honcho host key | aiPeer |
+|----------------|----------------|--------|
+| default | `hermes` | `hermes` |
+| orchestrator | `hermes.orchestrator` | `orchestrator` |
+| devops | `hermes.devops` | `devops` |
+| researcher | `hermes.researcher` | `researcher` |
+| dotnet-dev | `hermes.dotnet-dev` | `dotnet-dev` |
+| node-dev | `hermes.node-dev` | `node-dev` |
+| mobile-dev | `hermes.mobile-dev` | `mobile-dev` |
+
+All profiles share `peerName: mmalyska` and `workspace: hermes`.
 
 ## Maintenance Tasks
 

--- a/cluster/apps/default/hermes-agent/templates/deployment.yaml
+++ b/cluster/apps/default/hermes-agent/templates/deployment.yaml
@@ -54,6 +54,45 @@ spec:
               mountPath: /opt/data
             - name: config-template
               mountPath: /config-template
+        - name: honcho-seeder
+          image: "{{ .Values.hermes.image.repository }}:{{ .Values.hermes.image.tag }}"
+          command:
+            - python3
+            - -c
+            - |
+              import json, os
+
+              template_path = '/honcho-config/honcho.json'
+              target_path = '/opt/data/.hermes/honcho.json'
+
+              with open(template_path) as f:
+                  overrides = json.load(f)
+
+              os.makedirs(os.path.dirname(target_path), exist_ok=True)
+
+              if os.path.exists(target_path):
+                  with open(target_path) as f:
+                      config = json.load(f) or {}
+
+                  def deep_merge(base, src):
+                      for k, v in src.items():
+                          if isinstance(v, dict) and isinstance(base.get(k), dict):
+                              deep_merge(base[k], v)
+                          else:
+                              base[k] = v
+
+                  deep_merge(config, overrides)
+              else:
+                  config = overrides
+
+              with open(target_path, 'w') as f:
+                  json.dump(config, f, indent=2)
+
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+            - name: honcho-config
+              mountPath: /honcho-config
       containers:
         - name: hermes-agent
           image: "{{ .Values.hermes.image.repository }}:{{ .Values.hermes.image.tag }}"
@@ -116,3 +155,6 @@ spec:
         - name: nginx-config
           configMap:
             name: hermes-agent-nginx
+        - name: honcho-config
+          configMap:
+            name: hermes-agent-honcho

--- a/cluster/apps/default/hermes-agent/templates/honcho-configmap.yaml
+++ b/cluster/apps/default/hermes-agent/templates/honcho-configmap.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-agent-honcho
+  namespace: hermes-agent
+data:
+  honcho.json: |
+    {
+      "baseUrl": "http://honcho.honcho.svc.cluster.local:8000",
+      "observationMode": "directional",
+      "recallMode": "hybrid",
+      "sessionStrategy": "per-session",
+      "contextCadence": 1,
+      "dialecticCadence": 2,
+      "dialecticDepth": 1,
+      "hosts": {
+        "hermes": {
+          "enabled": true,
+          "aiPeer": "hermes",
+          "peerName": "mmalyska",
+          "workspace": "hermes"
+        },
+        "hermes.orchestrator": {
+          "enabled": true,
+          "aiPeer": "orchestrator",
+          "peerName": "mmalyska",
+          "workspace": "hermes"
+        },
+        "hermes.devops": {
+          "enabled": true,
+          "aiPeer": "devops",
+          "peerName": "mmalyska",
+          "workspace": "hermes"
+        },
+        "hermes.researcher": {
+          "enabled": true,
+          "aiPeer": "researcher",
+          "peerName": "mmalyska",
+          "workspace": "hermes"
+        },
+        "hermes.dotnet-dev": {
+          "enabled": true,
+          "aiPeer": "dotnet-dev",
+          "peerName": "mmalyska",
+          "workspace": "hermes"
+        },
+        "hermes.node-dev": {
+          "enabled": true,
+          "aiPeer": "node-dev",
+          "peerName": "mmalyska",
+          "workspace": "hermes"
+        },
+        "hermes.mobile-dev": {
+          "enabled": true,
+          "aiPeer": "mobile-dev",
+          "peerName": "mmalyska",
+          "workspace": "hermes"
+        }
+      }
+    }

--- a/cluster/apps/default/hermes-agent/values.yaml
+++ b/cluster/apps/default/hermes-agent/values.yaml
@@ -11,7 +11,7 @@ hermes:
   config:
     model:
       provider: openrouter
-      default: "deepseek/deepseek-v4-pro"
+      default: "deepseek/deepseek-v4-flash:free"
     approvals:
       mode: smart
     display:
@@ -29,6 +29,8 @@ hermes:
       sort: "price"
       data_collection: "deny"
     fallback_providers:
+      - provider: openrouter
+        model: "deepseek/deepseek-v4-pro"
       - provider: anthropic
         model: claude-sonnet-4-6
     auxiliary:

--- a/cluster/apps/default/hermes-agent/values.yaml
+++ b/cluster/apps/default/hermes-agent/values.yaml
@@ -18,6 +18,8 @@ hermes:
       show_cost: true
     dashboard:
       show_token_analytics: true
+    memory:
+      provider: honcho
     timezone: "Europe/Warsaw"
     discord:
       require_mention: true

--- a/cluster/apps/default/hermes-agent/values.yaml
+++ b/cluster/apps/default/hermes-agent/values.yaml
@@ -11,7 +11,7 @@ hermes:
   config:
     model:
       provider: openrouter
-      default: "deepseek/deepseek-v4-flash:free"
+      default: "deepseek/deepseek-v4-pro"
     approvals:
       mode: smart
     display:
@@ -30,7 +30,7 @@ hermes:
       data_collection: "deny"
     fallback_providers:
       - provider: openrouter
-        model: "deepseek/deepseek-v4-pro"
+        model: "deepseek/deepseek-v4-flash"
       - provider: anthropic
         model: claude-sonnet-4-6
     auxiliary:

--- a/cluster/apps/default/honcho/Chart.yaml
+++ b/cluster/apps/default/honcho/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: honcho
+type: application
+version: 1.0.0
+dependencies:
+  - name: pgsql-cnpg
+    version: 1.2.0
+    repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/default/honcho/README.md
+++ b/cluster/apps/default/honcho/README.md
@@ -1,0 +1,181 @@
+# Honcho — Self-Hosted Memory Server
+
+[Honcho](https://github.com/plastic-labs/honcho) v3 deployed as a self-hosted memory server in the `honcho` namespace, providing persistent cross-session user memory for hermes-agent via Theory-of-Mind (ToM) reasoning and vector recall.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                   namespace: honcho                       │
+│                                                          │
+│  ┌──────────────────┐      ┌───────────────────────────┐ │
+│  │  honcho-api      │      │  honcho-deriver           │ │
+│  │  :8000           │      │  (background worker)      │ │
+│  │  FastAPI +       │      │  python -m src.deriver    │ │
+│  │  migrations      │      │                           │ │
+│  └────────┬─────────┘      └────────────┬──────────────┘ │
+│           │                             │                 │
+│           └──────────────┬──────────────┘                 │
+│                          ▼                               │
+│              ┌───────────────────────┐                   │
+│              │  honchodb (CNPG)      │                   │
+│              │  PostgreSQL 17        │                   │
+│              │  + pgvector ext       │                   │
+│              │  2 replicas, 5Gi      │                   │
+│              └───────────────────────┘                   │
+└──────────────────────────────────────────────────────────┘
+        ▲
+        │  http://honcho.honcho.svc.cluster.local:8000
+        │
+┌───────┴───────────────────────────────────────────────────┐
+│  namespace: hermes-agent                                   │
+│  hermes-agent pod (honcho-seeder init → /opt/data/.hermes/│
+│  honcho.json, memory.provider: honcho in config.yaml)     │
+└───────────────────────────────────────────────────────────┘
+```
+
+| Component | Purpose |
+|-----------|---------|
+| **honcho-api** | REST API (`docker/entrypoint.sh` → alembic migrations + FastAPI on :8000). Migrations are idempotent and run on every start. |
+| **honcho-deriver** | Background Theory-of-Mind worker. Reads sessions queued by the API and derives user facts into the vector store. |
+| **honchodb (CNPG)** | CloudNativePG PostgreSQL 17 cluster with `pgvector` extension (standard bookworm image). Two replicas; S3 barman backup daily at 00:10. |
+| **ExternalSecret `honcho-secrets`** | Pulls OpenRouter API key + S3 credentials from Bitwarden via ESO. |
+| **Service `honcho`** | ClusterIP, port 8000. DNS: `honcho.honcho.svc.cluster.local:8000`. Not exposed outside the cluster (no HTTPRoute). |
+
+## LLM Model Strategy
+
+Honcho runs 9 distinct LLM module slots. All route through OpenRouter (`openai` transport) except embeddings.
+
+### Primary / Fallback
+
+Every module has a free-tier primary and a paid fallback. The fallback activates automatically on the **final retry attempt** — which covers 429 rate-limit exhaustion without any manual intervention.
+
+| Module | Primary | Fallback |
+|--------|---------|---------|
+| Deriver | `deepseek/deepseek-v4-flash:free` (free) | `deepseek/deepseek-v4-flash` ($0.10/$0.20) |
+| Summary | `deepseek/deepseek-v4-flash:free` (free) | `deepseek/deepseek-v4-flash` ($0.10/$0.20) |
+| Dream deduction | `deepseek/deepseek-v4-flash:free` (free) | `deepseek/deepseek-v4-flash` ($0.10/$0.20) |
+| Dream induction | `deepseek/deepseek-v4-flash:free` (free) | `deepseek/deepseek-v4-flash` ($0.10/$0.20) |
+| Dialectic minimal | `deepseek/deepseek-v4-flash:free` (free) | `deepseek/deepseek-v4-flash` ($0.10/$0.20) |
+| Dialectic low | `deepseek/deepseek-v4-flash:free` (free) | `deepseek/deepseek-v4-flash` ($0.10/$0.20) |
+| Dialectic medium | `deepseek/deepseek-v4-flash:free` (free) | `deepseek/deepseek-v4-flash` ($0.10/$0.20) |
+| Dialectic high | `qwen/qwen3-235b-a22b-2507` ($0.071/$0.10) | `deepseek/deepseek-v4-flash` ($0.10/$0.20) |
+| Dialectic max | `qwen/qwen3-235b-a22b-2507` ($0.071/$0.10) | `deepseek/deepseek-v4-flash` ($0.10/$0.20) |
+
+Prices are per 1M input/output tokens.
+
+### Embeddings
+
+Embeddings use **Ollama** (already in cluster, CPU-only) to avoid OpenRouter's lack of embedding endpoint support:
+
+- **Model**: `nomic-embed-text` (274 MB, 768 dimensions, fast on CPU)
+- **Endpoint**: `http://ollama.ha-ollama.svc.cluster.local:11434/v1`
+- **Cost**: free (local inference)
+- **Dimensions**: `EMBEDDING_VECTOR_DIMENSIONS=768`, `DIMENSIONS_MODE=never` (Ollama ignores the dimensions parameter)
+
+`nomic-embed-text` is included in Ollama's pull list via `cluster/apps/home-automation/ollama/values.yaml`.
+
+## Secrets
+
+| Secret key | Source (Bitwarden ID) | Used for |
+|------------|----------------------|---------|
+| `HONCHO_OPENROUTER_API_KEY` | `7ece641d-8f3e-42f6-b306-b45900a618ad` | All LLM calls via OpenRouter |
+| `S3_ACCESS_KEY_ID` | `e00e1e38-ae37-479a-8b46-b409016331eb` | CNPG S3 backup |
+| `S3_ACCESS_SECRET_KEY` | `4d5a418c-82ed-4b8e-bfbf-b40901634ea4` | CNPG S3 backup |
+
+All secrets are provisioned by `ExternalSecret honcho-secrets` (ESO + `ClusterSecretStore bitwarden`). The CNPG operator additionally creates `honchodb-cnpg-app` automatically with `username` and `password` for the database connection.
+
+## CNPG Database
+
+- **Image**: `ghcr.io/cloudnative-pg/postgresql:17.6-standard-bookworm` — bundles pgvector, no custom image needed
+- **Extension**: `CREATE EXTENSION IF NOT EXISTS vector` runs via `bootstrap.initdb.postInitApplicationSQL` on cluster creation
+- **Connection**: `DB_CONNECTION_URI` is built at runtime from `$(DB_USER):$(DB_PASS)` via Kubernetes dependent env vars (CNPG passwords are alphanumeric, URL-safe)
+- **Backup**: barman to `s3://k8s-at-home-backup/cnpg/honcho` daily at 00:10, 10-day retention. `<secret:s3_endpoint>` resolved at sync time via `cluster-secrets` plugin.
+
+## Helm Values (`values.yaml`)
+
+| Key | Purpose |
+|-----|---------|
+| `honcho.image` | API + deriver image (`ghcr.io/plastic-labs/honcho:v3.0.7`) |
+| `honcho.resources` | API container CPU/memory |
+| `honcho.deriver.resources` | Deriver container CPU/memory |
+| `openrouterBwsId` | Bitwarden secret ID for the OpenRouter API key |
+| `pgsql-cnpg.*` | CloudNativePG cluster config (replicas, storage, backup, pgvector bootstrap) |
+
+LLM module configuration lives entirely in `templates/_helpers.tpl` (`honcho.llmEnv` helper) — not in `values.yaml` — since the env var matrix is too large to template usefully.
+
+## hermes-agent Integration
+
+hermes-agent connects to Honcho via two additions applied at pod start by init containers:
+
+1. **`config-seeder`** merges `memory.provider: honcho` into `/opt/data/config.yaml`
+2. **`honcho-seeder`** deep-merges the `hermes-agent-honcho` ConfigMap into `/opt/data/.hermes/honcho.json`
+
+The `honcho.json` declares all 7 Hermes profiles as Honcho hosts:
+
+| Honcho host key | Hermes profile | aiPeer | workspace |
+|----------------|----------------|--------|-----------|
+| `hermes` | default | `hermes` | `hermes` |
+| `hermes.orchestrator` | orchestrator | `orchestrator` | `hermes` |
+| `hermes.devops` | devops | `devops` | `hermes` |
+| `hermes.researcher` | researcher | `researcher` | `hermes` |
+| `hermes.dotnet-dev` | dotnet-dev | `dotnet-dev` | `hermes` |
+| `hermes.node-dev` | node-dev | `node-dev` | `hermes` |
+| `hermes.mobile-dev` | mobile-dev | `mobile-dev` | `hermes` |
+
+All profiles share `peerName: mmalyska` and `workspace: hermes`. Deep-merge strategy means `hermes honcho sync` additions to `honcho.json` survive pod restarts while ConfigMap changes propagate on next restart.
+
+## Post-Deploy Validation
+
+```bash
+# All pods running
+kubectl -n honcho get pods
+
+# API health
+kubectl -n honcho exec deploy/honcho-api -- curl -s http://localhost:8000/health
+
+# pgvector extension present
+kubectl -n honcho exec honchodb-cnpg-1 -- psql -U app app -c \
+  "SELECT extname FROM pg_extension WHERE extname='vector';"
+
+# honcho.json seeded onto hermes-agent PVC
+kubectl -n hermes-agent exec deploy/hermes-agent -c hermes-agent -- \
+  cat /opt/data/.hermes/honcho.json
+
+# Memory provider active (in Discord/Signal)
+# hermes honcho status
+```
+
+## Maintenance
+
+### Viewing Logs
+
+```bash
+# API (migrations + FastAPI)
+kubectl logs deploy/honcho-api -n honcho --tail=100
+
+# Deriver (background memory worker)
+kubectl logs deploy/honcho-deriver -n honcho --tail=100 -f
+```
+
+### Updating the Image
+
+Edit `values.yaml` → bump `honcho.image.tag` → commit → ArgoCD syncs both deployments.
+
+### Checking CNPG Cluster Status
+
+```bash
+kubectl -n honcho get cluster honchodb-cnpg
+kubectl -n honcho get pods -l cnpg.io/cluster=honchodb-cnpg
+```
+
+### Tuning Memory Behaviour
+
+Edit `cluster/apps/default/hermes-agent/templates/honcho-configmap.yaml` and adjust:
+
+- `dialecticCadence` — how often deep memory recall runs (default: every 2 messages)
+- `contextCadence` — how often context is injected (default: every message)
+- `dialecticDepth` — reasoning depth (1 = shallow, 2+ = more thorough but slower)
+- `observationMode` / `recallMode` — observation and recall strategies
+
+Changes take effect on the next hermes-agent pod restart (the `honcho-seeder` re-merges the ConfigMap).

--- a/cluster/apps/default/honcho/app-config.yaml
+++ b/cluster/apps/default/honcho/app-config.yaml
@@ -1,0 +1,10 @@
+- enabled: "true"
+  namespace: honcho
+  syncPolicy:
+    enabled: true
+    selfHeal: true
+    prune: false
+  plugin:
+    env:
+      - name: SECRET_PROVIDER
+        value: cluster-secrets

--- a/cluster/apps/default/honcho/templates/_helpers.tpl
+++ b/cluster/apps/default/honcho/templates/_helpers.tpl
@@ -25,14 +25,26 @@
 - name: DERIVER_MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DERIVER_MODEL_CONFIG__MODEL
-  value: google/gemini-2.0-flash-lite-001
+  value: deepseek/deepseek-v4-flash:free
 - name: DERIVER_MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DERIVER_MODEL_CONFIG__FALLBACK__TRANSPORT
+  value: openai
+- name: DERIVER_MODEL_CONFIG__FALLBACK__MODEL
+  value: deepseek/deepseek-v4-flash
+- name: DERIVER_MODEL_CONFIG__FALLBACK__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 - name: SUMMARY_MODEL_CONFIG__TRANSPORT
   value: openai
 - name: SUMMARY_MODEL_CONFIG__MODEL
-  value: google/gemini-2.0-flash-lite-001
+  value: deepseek/deepseek-v4-flash:free
 - name: SUMMARY_MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: SUMMARY_MODEL_CONFIG__FALLBACK__TRANSPORT
+  value: openai
+- name: SUMMARY_MODEL_CONFIG__FALLBACK__MODEL
+  value: deepseek/deepseek-v4-flash
+- name: SUMMARY_MODEL_CONFIG__FALLBACK__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 - name: EMBEDDING_VECTOR_DIMENSIONS
   value: "768"
@@ -47,43 +59,85 @@
 - name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL
-  value: google/gemini-2.0-flash-lite-001
+  value: deepseek/deepseek-v4-flash:free
 - name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__FALLBACK__TRANSPORT
+  value: openai
+- name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__FALLBACK__MODEL
+  value: deepseek/deepseek-v4-flash
+- name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__FALLBACK__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 - name: DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL
-  value: google/gemini-2.0-flash-lite-001
+  value: deepseek/deepseek-v4-flash:free
 - name: DIALECTIC_LEVELS__low__MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DIALECTIC_LEVELS__low__MODEL_CONFIG__FALLBACK__TRANSPORT
+  value: openai
+- name: DIALECTIC_LEVELS__low__MODEL_CONFIG__FALLBACK__MODEL
+  value: deepseek/deepseek-v4-flash
+- name: DIALECTIC_LEVELS__low__MODEL_CONFIG__FALLBACK__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 - name: DIALECTIC_LEVELS__medium__MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DIALECTIC_LEVELS__medium__MODEL_CONFIG__MODEL
-  value: google/gemini-2.0-flash-001
+  value: deepseek/deepseek-v4-flash:free
 - name: DIALECTIC_LEVELS__medium__MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DIALECTIC_LEVELS__medium__MODEL_CONFIG__FALLBACK__TRANSPORT
+  value: openai
+- name: DIALECTIC_LEVELS__medium__MODEL_CONFIG__FALLBACK__MODEL
+  value: deepseek/deepseek-v4-flash
+- name: DIALECTIC_LEVELS__medium__MODEL_CONFIG__FALLBACK__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 - name: DIALECTIC_LEVELS__high__MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DIALECTIC_LEVELS__high__MODEL_CONFIG__MODEL
-  value: anthropic/claude-3.5-haiku
+  value: qwen/qwen3-235b-a22b-2507
 - name: DIALECTIC_LEVELS__high__MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DIALECTIC_LEVELS__high__MODEL_CONFIG__FALLBACK__TRANSPORT
+  value: openai
+- name: DIALECTIC_LEVELS__high__MODEL_CONFIG__FALLBACK__MODEL
+  value: deepseek/deepseek-v4-flash
+- name: DIALECTIC_LEVELS__high__MODEL_CONFIG__FALLBACK__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 - name: DIALECTIC_LEVELS__max__MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DIALECTIC_LEVELS__max__MODEL_CONFIG__MODEL
-  value: anthropic/claude-haiku-4.5
+  value: qwen/qwen3-235b-a22b-2507
 - name: DIALECTIC_LEVELS__max__MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DIALECTIC_LEVELS__max__MODEL_CONFIG__FALLBACK__TRANSPORT
+  value: openai
+- name: DIALECTIC_LEVELS__max__MODEL_CONFIG__FALLBACK__MODEL
+  value: deepseek/deepseek-v4-flash
+- name: DIALECTIC_LEVELS__max__MODEL_CONFIG__FALLBACK__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 - name: DREAM_DEDUCTION_MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DREAM_DEDUCTION_MODEL_CONFIG__MODEL
-  value: google/gemini-2.0-flash-lite-001
+  value: deepseek/deepseek-v4-flash:free
 - name: DREAM_DEDUCTION_MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DREAM_DEDUCTION_MODEL_CONFIG__FALLBACK__TRANSPORT
+  value: openai
+- name: DREAM_DEDUCTION_MODEL_CONFIG__FALLBACK__MODEL
+  value: deepseek/deepseek-v4-flash
+- name: DREAM_DEDUCTION_MODEL_CONFIG__FALLBACK__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 - name: DREAM_INDUCTION_MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DREAM_INDUCTION_MODEL_CONFIG__MODEL
-  value: google/gemini-2.0-flash-lite-001
+  value: deepseek/deepseek-v4-flash:free
 - name: DREAM_INDUCTION_MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DREAM_INDUCTION_MODEL_CONFIG__FALLBACK__TRANSPORT
+  value: openai
+- name: DREAM_INDUCTION_MODEL_CONFIG__FALLBACK__MODEL
+  value: deepseek/deepseek-v4-flash
+- name: DREAM_INDUCTION_MODEL_CONFIG__FALLBACK__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 {{- end -}}

--- a/cluster/apps/default/honcho/templates/_helpers.tpl
+++ b/cluster/apps/default/honcho/templates/_helpers.tpl
@@ -25,61 +25,65 @@
 - name: DERIVER_MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DERIVER_MODEL_CONFIG__MODEL
-  value: google/gemini-flash-1.5
+  value: google/gemini-2.0-flash-lite-001
 - name: DERIVER_MODEL_CONFIG__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 - name: SUMMARY_MODEL_CONFIG__TRANSPORT
   value: openai
 - name: SUMMARY_MODEL_CONFIG__MODEL
-  value: google/gemini-flash-1.5
+  value: google/gemini-2.0-flash-lite-001
 - name: SUMMARY_MODEL_CONFIG__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
+- name: EMBEDDING_VECTOR_DIMENSIONS
+  value: "768"
 - name: EMBEDDING_MODEL_CONFIG__TRANSPORT
   value: openai
 - name: EMBEDDING_MODEL_CONFIG__MODEL
-  value: openai/text-embedding-3-small
+  value: nomic-embed-text
+- name: EMBEDDING_MODEL_CONFIG__DIMENSIONS_MODE
+  value: never
 - name: EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL
-  value: https://openrouter.ai/api/v1
+  value: http://ollama.ha-ollama.svc.cluster.local:11434/v1
 - name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL
-  value: google/gemini-flash-1.5
+  value: google/gemini-2.0-flash-lite-001
 - name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 - name: DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL
-  value: google/gemini-flash-1.5
+  value: google/gemini-2.0-flash-lite-001
 - name: DIALECTIC_LEVELS__low__MODEL_CONFIG__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 - name: DIALECTIC_LEVELS__medium__MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DIALECTIC_LEVELS__medium__MODEL_CONFIG__MODEL
-  value: google/gemini-2.0-flash
+  value: google/gemini-2.0-flash-001
 - name: DIALECTIC_LEVELS__medium__MODEL_CONFIG__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 - name: DIALECTIC_LEVELS__high__MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DIALECTIC_LEVELS__high__MODEL_CONFIG__MODEL
-  value: anthropic/claude-3-5-haiku
+  value: anthropic/claude-3.5-haiku
 - name: DIALECTIC_LEVELS__high__MODEL_CONFIG__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 - name: DIALECTIC_LEVELS__max__MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DIALECTIC_LEVELS__max__MODEL_CONFIG__MODEL
-  value: anthropic/claude-3-5-sonnet
+  value: anthropic/claude-haiku-4.5
 - name: DIALECTIC_LEVELS__max__MODEL_CONFIG__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 - name: DREAM_DEDUCTION_MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DREAM_DEDUCTION_MODEL_CONFIG__MODEL
-  value: google/gemini-flash-1.5
+  value: google/gemini-2.0-flash-lite-001
 - name: DREAM_DEDUCTION_MODEL_CONFIG__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 - name: DREAM_INDUCTION_MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DREAM_INDUCTION_MODEL_CONFIG__MODEL
-  value: google/gemini-flash-1.5
+  value: google/gemini-2.0-flash-lite-001
 - name: DREAM_INDUCTION_MODEL_CONFIG__OVERRIDES__BASE_URL
   value: https://openrouter.ai/api/v1
 {{- end -}}

--- a/cluster/apps/default/honcho/templates/_helpers.tpl
+++ b/cluster/apps/default/honcho/templates/_helpers.tpl
@@ -1,0 +1,85 @@
+{{- define "honcho.llmEnv" -}}
+- name: DB_USER
+  valueFrom:
+    secretKeyRef:
+      name: honchodb-cnpg-app
+      key: username
+- name: DB_PASS
+  valueFrom:
+    secretKeyRef:
+      name: honchodb-cnpg-app
+      key: password
+- name: DB_CONNECTION_URI
+  value: "postgresql+psycopg://$(DB_USER):$(DB_PASS)@honchodb-cnpg-rw.honcho.svc.cluster.local:5432/app"
+- name: AUTH_USE_AUTH
+  value: "false"
+- name: SENTRY_ENABLED
+  value: "false"
+- name: CACHE_ENABLED
+  value: "false"
+- name: LLM_OPENAI_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: honcho-secrets
+      key: HONCHO_OPENROUTER_API_KEY
+- name: DERIVER_MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DERIVER_MODEL_CONFIG__MODEL
+  value: google/gemini-flash-1.5
+- name: DERIVER_MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: SUMMARY_MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: SUMMARY_MODEL_CONFIG__MODEL
+  value: google/gemini-flash-1.5
+- name: SUMMARY_MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: EMBEDDING_MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: EMBEDDING_MODEL_CONFIG__MODEL
+  value: openai/text-embedding-3-small
+- name: EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL
+  value: google/gemini-flash-1.5
+- name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL
+  value: google/gemini-flash-1.5
+- name: DIALECTIC_LEVELS__low__MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DIALECTIC_LEVELS__medium__MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DIALECTIC_LEVELS__medium__MODEL_CONFIG__MODEL
+  value: google/gemini-2.0-flash
+- name: DIALECTIC_LEVELS__medium__MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DIALECTIC_LEVELS__high__MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DIALECTIC_LEVELS__high__MODEL_CONFIG__MODEL
+  value: anthropic/claude-3-5-haiku
+- name: DIALECTIC_LEVELS__high__MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DIALECTIC_LEVELS__max__MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DIALECTIC_LEVELS__max__MODEL_CONFIG__MODEL
+  value: anthropic/claude-3-5-sonnet
+- name: DIALECTIC_LEVELS__max__MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DREAM_DEDUCTION_MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DREAM_DEDUCTION_MODEL_CONFIG__MODEL
+  value: google/gemini-flash-1.5
+- name: DREAM_DEDUCTION_MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+- name: DREAM_INDUCTION_MODEL_CONFIG__TRANSPORT
+  value: openai
+- name: DREAM_INDUCTION_MODEL_CONFIG__MODEL
+  value: google/gemini-flash-1.5
+- name: DREAM_INDUCTION_MODEL_CONFIG__OVERRIDES__BASE_URL
+  value: https://openrouter.ai/api/v1
+{{- end -}}

--- a/cluster/apps/default/honcho/templates/deployment-api.yaml
+++ b/cluster/apps/default/honcho/templates/deployment-api.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: honcho-api
+  namespace: honcho
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: honcho-api
+  template:
+    metadata:
+      labels:
+        app: honcho-api
+    spec:
+      containers:
+        - name: honcho-api
+          image: "{{ .Values.honcho.image.repository }}:{{ .Values.honcho.image.tag }}"
+          command: ["sh", "docker/entrypoint.sh"]
+          env:
+            {{- include "honcho.llmEnv" . | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+          resources: {{toYaml .Values.honcho.resources | nindent 12}}

--- a/cluster/apps/default/honcho/templates/deployment-deriver.yaml
+++ b/cluster/apps/default/honcho/templates/deployment-deriver.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: honcho-deriver
+  namespace: honcho
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: honcho-deriver
+  template:
+    metadata:
+      labels:
+        app: honcho-deriver
+    spec:
+      containers:
+        - name: honcho-deriver
+          image: "{{ .Values.honcho.image.repository }}:{{ .Values.honcho.image.tag }}"
+          command: ["/app/.venv/bin/python", "-m", "src.deriver"]
+          env:
+            {{- include "honcho.llmEnv" . | nindent 12 }}
+          resources: {{toYaml .Values.honcho.deriver.resources | nindent 12}}

--- a/cluster/apps/default/honcho/templates/externalsecret.yaml
+++ b/cluster/apps/default/honcho/templates/externalsecret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: honcho-secrets
+  namespace: honcho
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  refreshInterval: 1h
+  target:
+    name: honcho-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: HONCHO_OPENROUTER_API_KEY
+      remoteRef:
+        key: {{ .Values.openrouterBwsId | quote }}
+    - secretKey: S3_ACCESS_KEY_ID
+      remoteRef:
+        key: "e00e1e38-ae37-479a-8b46-b409016331eb" #gitleaks:allow #S3_ACCESS_KEY
+    - secretKey: S3_ACCESS_SECRET_KEY
+      remoteRef:
+        key: "4d5a418c-82ed-4b8e-bfbf-b40901634ea4" #gitleaks:allow #S3_SECRET_KEY

--- a/cluster/apps/default/honcho/templates/service.yaml
+++ b/cluster/apps/default/honcho/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: honcho
+  namespace: honcho
+spec:
+  type: ClusterIP
+  selector:
+    app: honcho-api
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+      protocol: TCP

--- a/cluster/apps/default/honcho/values.yaml
+++ b/cluster/apps/default/honcho/values.yaml
@@ -1,0 +1,57 @@
+honcho:
+  image:
+    repository: ghcr.io/plastic-labs/honcho
+    tag: "v3.0.7"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+  deriver:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
+openrouterBwsId: "7ece641d-8f3e-42f6-b306-b45900a618ad" #gitleaks:allow #HONCHO_OPENROUTER_API_KEY
+
+pgsql-cnpg:
+  name: honchodb
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.6-standard-bookworm
+  instances: 2
+  storage:
+    size: 5Gi
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 100m
+    limits:
+      memory: 512Mi
+      cpu: 500m
+  bootstrap:
+    initdb:
+      postInitApplicationSQL:
+        - CREATE EXTENSION IF NOT EXISTS vector
+  monitoring:
+    enablePodMonitor: true
+  backup:
+    retentionPolicy: "10d"
+    barmanObjectStore:
+      destinationPath: "s3://k8s-at-home-backup/cnpg/honcho"
+      endpointURL: <secret:s3_endpoint>
+      s3Credentials:
+        accessKeyId:
+          name: honcho-secrets
+          key: S3_ACCESS_KEY_ID
+        secretAccessKey:
+          name: honcho-secrets
+          key: S3_ACCESS_SECRET_KEY
+  scheduledBackups:
+    - name: honchodb-cnpg-backup
+      spec:
+        immediate: true
+        schedule: "10 0 0 * * *"
+        backupOwnerReference: self

--- a/cluster/apps/home-automation/ollama/values.yaml
+++ b/cluster/apps/home-automation/ollama/values.yaml
@@ -5,6 +5,7 @@ ollama:
         - deepcoder:14b
         - qwen3.5:9b
         - gemma4:26b
+        - nomic-embed-text
   extraEnv:
     - name: OLLAMA_KV_CACHE_TYPE
       value: "q4_0"


### PR DESCRIPTION
## Summary

- **New app** `cluster/apps/default/honcho/` — self-hosted [Honcho](https://github.com/plastic-labs/honcho) v3.0.7 as a persistent memory provider for hermes-agent
- **CNPG cluster** `honchodb-cnpg` using `ghcr.io/cloudnative-pg/postgresql:17.6-standard-bookworm` (standard image with pgvector built in); pgvector extension enabled via `postInitApplicationSQL`
- **Two Deployments**: `honcho-api` (FastAPI + idempotent migrations via `docker/entrypoint.sh`) and `honcho-deriver` (background reasoning worker)
- **OpenRouter as LLM backend** via a new dedicated Bitwarden key (`7ece641d-8f3e-42f6-b306-b45900a618ad`) — all 10 Honcho modules (DERIVER, SUMMARY, EMBEDDING, 5 DIALECTIC levels, 2 DREAM) routed through OpenRouter; cheap models for background work, better models for high/max dialectic
- **hermes-agent wired**: `memory.provider: honcho` deep-merged into config.yaml via existing config-seeder; new `honcho-seeder` init-container deep-merges `honcho.json` to `/opt/data/.hermes/honcho.json` on every restart (preserves runtime additions from `hermes honcho sync`)
- **All 7 profiles** pre-configured in `honcho.json`: `default`→`hermes`, `orchestrator`, `devops`, `researcher`, `dotnet-dev`, `node-dev`, `mobile-dev`; shared workspace `hermes`, shared peerName `mmalyska`, separate `aiPeer` per profile
- **S3 backup** for `honchodb-cnpg` to `s3://k8s-at-home-backup/cnpg/honcho` (same bucket/credentials as litellm/keycloak)
- **No Redis** — `CACHE_ENABLED=false` for simplicity; can be added later
- **No public exposure** — Honcho is ClusterIP only; hermes-agent accesses it via `http://honcho.honcho.svc.cluster.local:8000`

## ArgoCD sync order

1. Sync `honcho` app first → wait for `honcho-api` pod to pass readiness probe (`GET /health`)
2. Restart hermes-agent (`kubectl rollout restart deploy/hermes-agent -n hermes-agent`) — init-containers run, `honcho.json` is seeded

## Post-deploy validation

```bash
# 1. All Honcho pods running
kubectl -n honcho get pods

# 2. API health
kubectl -n honcho exec deploy/honcho-api -- curl -s http://localhost:8000/health

# 3. pgvector extension active
kubectl -n honcho exec honchodb-cnpg-1 -- psql -U app app -c "SELECT extname FROM pg_extension WHERE extname='vector';"

# 4. honcho.json placed on hermes PVC
kubectl -n hermes-agent exec deploy/hermes-agent -c hermes-agent -- cat /opt/data/.hermes/honcho.json

# 5. Hermes recognises provider (in Discord/Signal)
# Send: hermes honcho status
```

## Rollback

- **Disable memory only**: remove `memory.provider: honcho` from `hermes-agent/values.yaml` → redeploy hermes-agent. Honcho data preserved.
- **Full disable**: set `enabled: "false"` in `cluster/apps/default/honcho/app-config.yaml`. CNPG PVC survives for restore.