### PR TITLE
fix(hermes-agent): seed honcho.json to all worker profile directories

### DIFF
--- a/cluster/apps/default/hermes-agent/templates/deployment.yaml
+++ b/cluster/apps/default/hermes-agent/templates/deployment.yaml
@@ -88,6 +88,17 @@ spec:
               with open(target_path, 'w') as f:
                   json.dump(config, f, indent=2)
 
+              # Seed honcho.json to worker profile directories
+              profiles_dir = '/opt/data/profiles'
+              if os.path.isdir(profiles_dir):
+                  for profile in os.listdir(profiles_dir):
+                      profile_hermes = os.path.join(profiles_dir, profile, '.hermes')
+                      os.makedirs(profile_hermes, exist_ok=True)
+                      profile_target = os.path.join(profile_hermes, 'honcho.json')
+                      if not os.path.exists(profile_target):
+                          with open(profile_target, 'w') as f:
+                              json.dump(config, f, indent=2)
+
           volumeMounts:
             - name: data
               mountPath: /opt/data


### PR DESCRIPTION
## Problem

Init container `honcho-seeder` zapisywał `honcho.json` tylko do defaultowego profilu (`/opt/data/.hermes/honcho.json`). Worker profile (orchestrator, devops, researcher, dotnet-dev, node-dev, mobile-dev) nie miały pliku `honcho.json` w swoich katalogach `.hermes/`, więc nie mogły się połączyć z serwerem Honcho jako memory provider.

Dodatkowo, katalogi `.hermes/` dla worker profili w ogóle nie istniały (są tworzone dopiero przy pierwszym uruchomieniu profilu).

## Rozwiązanie

Rozszerzam `honcho-seeder` o pętlę, która po zapisaniu głównego `honcho.json` przechodzi przez wszystkie katalogi w `/opt/data/profiles/` i:

1. Tworzy katalog `.hermes/` jeśli nie istnieje (`os.makedirs`)
2. Zapisuje `honcho.json` tylko jeśli jeszcze go nie ma (`if not os.path.exists`) — nie nadpisuje istniejących, żeby nie zgubić runtime'owych zmian

Logika `deep_merge` zostaje tylko dla defaultowego profilu (jak było). Worker profile dostają czystą kopię z ConfigMapa przy pierwszym starcie — potem ich pliki są nietknięte.