### PR TITLE
fix(hermes-agent): install honcho-ai and create config symlink in init container

### DIFF
--- a/cluster/apps/default/hermes-agent/templates/deployment.yaml
+++ b/cluster/apps/default/hermes-agent/templates/deployment.yaml
@@ -57,12 +57,9 @@ spec:
         - name: honcho-seeder
           image: "{{ .Values.hermes.image.repository }}:{{ .Values.hermes.image.tag }}"
           command:
-            - sh
+            - python3
             - -c
             - |
-              pip install honcho-ai
-
-              python3 -c "
               import json, os
 
               template_path = '/honcho-config/honcho.json'
@@ -108,7 +105,6 @@ spec:
               symlink_target = os.path.join(honcho_config_dir, 'config.json')
               if not os.path.exists(symlink_target):
                   os.symlink(target_path, symlink_target)
-              "
 
           volumeMounts:
             - name: data
@@ -118,9 +114,9 @@ spec:
       containers:
         - name: hermes-agent
           image: "{{ .Values.hermes.image.repository }}:{{ .Values.hermes.image.tag }}"
+          command: ["sh", "-c"]
           args:
-            - gateway
-            - run
+            - "/opt/hermes/.venv/bin/pip install honcho-ai && exec /opt/hermes/.venv/bin/hermes gateway run"
           env:
             - name: HOME
               value: /opt/data

--- a/cluster/apps/default/hermes-agent/templates/deployment.yaml
+++ b/cluster/apps/default/hermes-agent/templates/deployment.yaml
@@ -104,7 +104,7 @@ spec:
 
               # Symlink for honcho-ai client (~/.honcho/config.json -> ~/.hermes/honcho.json)
               honcho_config_dir = os.path.expanduser('~/.honcho')
-              os.makedirs(hocho_config_dir, exist_ok=True)
+              os.makedirs(honcho_config_dir, exist_ok=True)
               symlink_target = os.path.join(honcho_config_dir, 'config.json')
               if not os.path.exists(symlink_target):
                   os.symlink(target_path, symlink_target)

--- a/cluster/apps/default/hermes-agent/templates/deployment.yaml
+++ b/cluster/apps/default/hermes-agent/templates/deployment.yaml
@@ -57,9 +57,12 @@ spec:
         - name: honcho-seeder
           image: "{{ .Values.hermes.image.repository }}:{{ .Values.hermes.image.tag }}"
           command:
-            - python3
+            - sh
             - -c
             - |
+              pip install honcho-ai
+
+              python3 -c "
               import json, os
 
               template_path = '/honcho-config/honcho.json'
@@ -98,6 +101,14 @@ spec:
                       if not os.path.exists(profile_target):
                           with open(profile_target, 'w') as f:
                               json.dump(config, f, indent=2)
+
+              # Symlink for honcho-ai client (~/.honcho/config.json -> ~/.hermes/honcho.json)
+              honcho_config_dir = os.path.expanduser('~/.honcho')
+              os.makedirs(hocho_config_dir, exist_ok=True)
+              symlink_target = os.path.join(honcho_config_dir, 'config.json')
+              if not os.path.exists(symlink_target):
+                  os.symlink(target_path, symlink_target)
+              "
 
           volumeMounts:
             - name: data

--- a/cluster/apps/default/hermes-agent/templates/deployment.yaml
+++ b/cluster/apps/default/hermes-agent/templates/deployment.yaml
@@ -63,12 +63,13 @@ spec:
               import json, os
 
               template_path = '/honcho-config/honcho.json'
-              target_path = '/opt/data/.hermes/honcho.json'
 
               with open(template_path) as f:
                   overrides = json.load(f)
 
-              os.makedirs(os.path.dirname(target_path), exist_ok=True)
+              # Write to $HERMES_HOME/honcho.json (primary read path for default profile)
+              hermes_home = os.environ.get('HERMES_HOME', '/opt/data')
+              target_path = os.path.join(hermes_home, 'honcho.json')
 
               if os.path.exists(target_path):
                   with open(target_path) as f:
@@ -89,28 +90,24 @@ spec:
                   json.dump(config, f, indent=2)
 
               # Seed honcho.json to worker profile directories
-              profiles_dir = '/opt/data/profiles'
+              # Worker profiles read from $HERMES_HOME/honcho.json
+              # which resolves to /opt/data/profiles/<name>/honcho.json
+              profiles_dir = os.path.join(hermes_home, 'profiles')
               if os.path.isdir(profiles_dir):
                   for profile in os.listdir(profiles_dir):
-                      profile_hermes = os.path.join(profiles_dir, profile, '.hermes')
-                      os.makedirs(profile_hermes, exist_ok=True)
-                      profile_target = os.path.join(profile_hermes, 'honcho.json')
+                      profile_target = os.path.join(profiles_dir, profile, 'honcho.json')
                       if not os.path.exists(profile_target):
                           with open(profile_target, 'w') as f:
                               json.dump(config, f, indent=2)
-
-              # Symlink for honcho-ai client (~/.honcho/config.json -> ~/.hermes/honcho.json)
-              honcho_config_dir = os.path.expanduser('~/.honcho')
-              os.makedirs(honcho_config_dir, exist_ok=True)
-              symlink_target = os.path.join(honcho_config_dir, 'config.json')
-              if not os.path.exists(symlink_target):
-                  os.symlink(target_path, symlink_target)
 
           volumeMounts:
             - name: data
               mountPath: /opt/data
             - name: honcho-config
               mountPath: /honcho-config
+          env:
+            - name: HERMES_HOME
+              value: /opt/data
       containers:
         - name: hermes-agent
           image: "{{ .Values.hermes.image.repository }}:{{ .Values.hermes.image.tag }}"


### PR DESCRIPTION
## Problem

Po restarcie poda `honcho-ai` paczka znika (instalacja w ephemeral filesystem), a `hermes honcho status` pokazuje "honcho-ai is not installed". Dodatkowo klient `honcho-ai` szuka configa w `~/.honcho/config.json`, a `honcho-seeder` zapisuje do `~/.hermes/honcho.json` — brak symlinka powoduje "No Honcho config found".

## Rozwiązanie

Rozszerzam init container `honcho-seeder` o dwie rzeczy:

1. **`pip install honcho-ai`** — przed skryptem Pythona, instaluje paczkę na każdym starcie poda
2. **Symlink** `~/.honcho/config.json` → `~/.hermes/honcho.json` — tworzony przez skrypt Python po zapisaniu plików (idempotentnie, `if not os.path.exists`)

Zmiana z `python3 -c` na `sh -c` z dwoma krokami — najpierw pip, potem python.