### PR TITLE
fix(hermes-agent): use uv to install honcho-ai, write to HERMES_HOME/honcho.json

### DIFF
--- a/cluster/apps/default/hermes-agent/templates/deployment.yaml
+++ b/cluster/apps/default/hermes-agent/templates/deployment.yaml
@@ -111,9 +111,9 @@ spec:
       containers:
         - name: hermes-agent
           image: "{{ .Values.hermes.image.repository }}:{{ .Values.hermes.image.tag }}"
+          command: ["sh", "-c"]
           args:
-            - gateway
-            - run
+            - "VIRTUAL_ENV=/opt/hermes/.venv uv pip install honcho-ai && exec /opt/hermes/.venv/bin/hermes gateway run"
           env:
             - name: HOME
               value: /opt/data


### PR DESCRIPTION
## Problem

Poprzednia wersja używała `/opt/hermes/.venv/bin/pip` — ale obraz `nousresearch/hermes-agent` **nie zawiera pip** (ani `python3 -m pip`, ani `ensurepip`).

## Rozwiązanie

Używam `uv` (`/usr/local/bin/uv`), który jest w obrazie i jest też Tier-1 strategią w `hermes` ownym `lazy_deps._venv_pip_install`:

```yaml
command: ["sh", "-c"]
args:
  - "VIRTUAL_ENV=/opt/hermes/.venv uv pip install honcho-ai && exec /opt/hermes/.venv/bin/hermes gateway run"
```

`VIRTUAL_ENV` mówi `uv` do którego venva instalować. `exec` przekazuje PID 1 do hermesa.

## Zmiany w honcho-seeder

- Zapisuje do `$HERMES_HOME/honcho.json` (pierwsza ścieżka resolved przez Hermesa), nie do `~/.hermes/honcho.json`
- Seeduje worker profile do `/opt/data/profiles/<name>/honcho.json`
- Zero symlinków — niepotrzebne