### PR TITLE
fix(hermes-agent): use postStart hook for honcho-ai install, don't override command

### DIFF
--- a/cluster/apps/default/hermes-agent/templates/deployment.yaml
+++ b/cluster/apps/default/hermes-agent/templates/deployment.yaml
@@ -111,9 +111,16 @@ spec:
       containers:
         - name: hermes-agent
           image: "{{ .Values.hermes.image.repository }}:{{ .Values.hermes.image.tag }}"
-          command: ["sh", "-c"]
           args:
-            - "VIRTUAL_ENV=/opt/hermes/.venv uv pip install honcho-ai && exec /opt/hermes/.venv/bin/hermes gateway run"
+            - gateway
+            - run
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - "VIRTUAL_ENV=/opt/hermes/.venv uv pip install honcho-ai"
           env:
             - name: HOME
               value: /opt/data


### PR DESCRIPTION
## Problem

Poprzedni PR (#4005) nadpisywał `command` w main kontenerze (`command: ["sh", "-c"]`), co **omijało s6-overlay ENTRYPOINT** (`/init`). Bez s6-overlay nie działają:
- `cont-init.d` (chown, seed configu, skills sync)
- `02-reconcile-profiles` (odtwarzanie gatewayy profili)
- Dashboard
- PID 1 supervision

Efekt: multiattach error na PVC podczas rolling update (pod nie mógł poprawnie wystartować).

## Rozwiązanie

Usuwam `command` override. Zamiast tego używam `lifecycle.postStart` hooka, który odpala `uv pip install` **w już działającym kontenerze**, nie ruszając entrypointa:

```yaml
args:
  - gateway
  - run          # ← z powrotem oryginalne, przez s6-overlay
lifecycle:
  postStart:
    exec:
      command:
        - sh
        - -c
        - "VIRTUAL_ENV=/opt/hermes/.venv uv pip install honcho-ai"
```

`postStart` leci asynchronicznie po starcie kontenera — paczka instaluje się w <2s, hermes i tak potrzebuje chwili na inicjalizację memory providera.