### PR TITLE
feat(argocd): add ai AppProject and ApplicationSet

### DIFF
--- a/cluster/appsets/appset-ai.yaml
+++ b/cluster/appsets/appset-ai.yaml
@@ -1,0 +1,86 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: appset-ai
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  syncPolicy:
+    applicationsSync: create-update
+    preserveResourcesOnDeletion: false # To prevent an Application's child resources from being deleted when the parent Application is deleted set this to true
+  generators:
+    - git:
+        repoURL: https://github.com/mmalyska/home-ops
+        revision: main
+        files:
+          - path: cluster/apps/ai/*/app-config.yaml
+        values:
+          appName: "{{.path.basename}}"
+      selector:
+        matchExpressions:
+          - key: enabled
+            operator: In
+            values:
+              - "true"
+  template:
+    metadata:
+      name: "{{.values.appName}}"
+      namespace: argocd
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true
+        argocd.argoproj.io/manifest-generate-paths: .
+    spec:
+      project: ai
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "{{.namespace}}"
+      syncPolicy:
+        syncOptions:
+          - CreateNamespace=true
+          - PruneLast=true
+          - RespectIgnoreDifferences=true
+          - ServerSideApply=true
+          - ApplyOutOfSyncOnly=true
+        automated:
+          prune: false
+          selfHeal: true
+  templatePatch: |
+    {{- if or (hasKey . "appSubfolder") (hasKey . "syncWave") }}
+    metadata:
+      {{- if hasKey . "appSubfolder" }}
+      name: '{{.values.appName}}-{{.appSubfolder}}'
+      {{- end }}
+      {{- if hasKey . "syncWave" }}
+      annotations:
+        argocd.argoproj.io/sync-wave: "{{.syncWave}}"
+      {{- end }}
+    {{- end }}
+    spec:
+      source:
+        repoURL: https://github.com/mmalyska/home-ops
+        targetRevision: main
+      {{- if hasKey . "appSubfolder" }}
+        path: '{{.path.path}}/{{.appSubfolder}}'
+      {{- else }}
+        path: '{{.path.path}}'
+      {{- end }}
+      {{- if hasKey . "plugin" }}
+        plugin:
+          {{- .plugin | toYaml | nindent 12 }}
+      {{- end }}
+      syncPolicy:
+      {{- if hasKey . "managedNamespaceMetadata" }}
+        managedNamespaceMetadata:
+          {{- .managedNamespaceMetadata | toYaml | nindent 10 }}
+      {{- end }}
+        automated:
+          enabled: {{ .syncPolicy.enabled }}
+          prune: {{ .syncPolicy.prune }}
+          selfHeal: {{.syncPolicy.selfHeal}}
+      {{- if hasKey . "ignoreDifferences" }}
+      ignoreDifferences:
+        {{- .ignoreDifferences | toYaml | nindent 12 }}
+      {{- end }}

--- a/cluster/projects/ai.yaml
+++ b/cluster/projects/ai.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: ai
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  clusterResourceWhitelist:
+    - group: "*"
+      kind: "*"
+  description: AI, LLM, and code-agent apps
+  destinations:
+    - name: "*"
+      namespace: "*"
+      server: "*"
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"
+  sourceRepos:
+    - "*"


### PR DESCRIPTION
## Summary

- Creates `cluster/projects/ai.yaml` — new ArgoCD AppProject for AI/LLM workloads
- Creates `cluster/appsets/appset-ai.yaml` — ApplicationSet watching `cluster/apps/ai/*/app-config.yaml`
- Creates `cluster/apps/ai/.gitkeep` — seeds the new category directory

This is PR 1 of 8 in the AI project migration. Merge this first; it establishes the empty project before any apps are moved into it.

## Test plan

- [ ] Verify ArgoCD project `ai` appears in the UI after merge
- [ ] Verify `appset-ai` ApplicationSet is present with 0 applications