### PR TITLE
chore(argocd): set preserveResourcesOnDeletion=true on appset-default before ai migration

### DIFF
--- a/cluster/appsets/appset-default.yaml
+++ b/cluster/appsets/appset-default.yaml
@@ -10,7 +10,7 @@ spec:
   goTemplateOptions: ["missingkey=error"]
   syncPolicy:
     applicationsSync: create-update
-    preserveResourcesOnDeletion: false # To prevent an Application's child resources from being deleted when the parent Application is deleted set this to true
+    preserveResourcesOnDeletion: true # To prevent an Application's child resources from being deleted when the parent Application is deleted set this to true
   generators:
     - git:
         repoURL: https://github.com/mmalyska/home-ops


### PR DESCRIPTION
## Summary

- Sets `preserveResourcesOnDeletion: true` on `appset-default`

This is PR 2 of 8 in the AI project migration. Must be merged **after PR #4020** and **before** any app is moved out of the `default` category. This prevents cascade-deletion of K8s resources (PVCs, CNPG databases) when ArgoCD removes the old Applications as apps move to the `ai` project.

Will be reverted in PR 8 once all migrations are complete.

## Test plan

- [x] Verify `appset-default` ApplicationSet shows `preserveResourcesOnDeletion: true` in ArgoCD UI after merge