### PR TITLE
chore(argocd): restore preserveResourcesOnDeletion=false on appset-default

### DIFF
--- a/cluster/appsets/appset-default.yaml
+++ b/cluster/appsets/appset-default.yaml
@@ -10,7 +10,7 @@ spec:
   goTemplateOptions: ["missingkey=error"]
   syncPolicy:
     applicationsSync: create-update
-    preserveResourcesOnDeletion: true # To prevent an Application's child resources from being deleted when the parent Application is deleted set this to true
+    preserveResourcesOnDeletion: false # To prevent an Application's child resources from being deleted when the parent Application is deleted set this to true
   generators:
     - git:
         repoURL: https://github.com/mmalyska/home-ops


### PR DESCRIPTION
Reverts the temporary preserveResourcesOnDeletion=true set in PR #4021 now that all AI project migrations are complete.

PR 8 of 8 in AI project migration.