### PR TITLE
fix(honcho): add CNPG recovery bootstrap and fix ollama svc URL

### DIFF
--- a/cluster/apps/ai/honcho/templates/_helpers.tpl
+++ b/cluster/apps/ai/honcho/templates/_helpers.tpl
@@ -55,7 +55,7 @@
 - name: EMBEDDING_MODEL_CONFIG__DIMENSIONS_MODE
   value: never
 - name: EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL
-  value: http://ollama.ha-ollama.svc.cluster.local:11434/v1
+  value: http://ollama.ollama.svc.cluster.local:11434/v1
 - name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__TRANSPORT
   value: openai
 - name: DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL

--- a/cluster/apps/ai/honcho/values.yaml
+++ b/cluster/apps/ai/honcho/values.yaml
@@ -32,9 +32,21 @@ pgsql-cnpg:
       memory: 512Mi
       cpu: 500m
   bootstrap:
-    initdb:
-      postInitApplicationSQL:
-        - CREATE EXTENSION IF NOT EXISTS vector
+    recovery:
+      source: honchodb-cnpg-backup
+  externalClusters:
+    - name: honchodb-cnpg-backup
+      barmanObjectStore:
+        serverName: honchodb
+        destinationPath: "s3://k8s-at-home-backup/cnpg/honcho"
+        endpointURL: <secret:s3_endpoint>
+        s3Credentials:
+          accessKeyId:
+            name: honcho-secrets
+            key: S3_ACCESS_KEY_ID
+          secretAccessKey:
+            name: honcho-secrets
+            key: S3_ACCESS_SECRET_KEY
   monitoring:
     enablePodMonitor: true
   backup:


### PR DESCRIPTION
## Summary

- Adds `bootstrap.recovery` to honchodb CNPG cluster pointing to S3 backup at `s3://k8s-at-home-backup/cnpg/honcho` — ensures the database restores from backup when the cluster is recreated rather than starting fresh
- Adds `serverName: honchodb` so CNPG looks in the correct S3 path for the existing backup
- Fixes `EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL` in `_helpers.tpl`: `ha-ollama` → `ollama` namespace

## After merging

Delete the existing CNPG cluster to force recreation with recovery bootstrap:
```
kubectl delete cluster honchodb-cnpg -n honcho
```
ArgoCD will recreate it and restore from the S3 backup.