### PR TITLE
fix(honcho): use system-bookworm image with barman-cloud and pgvector

### DIFF
--- a/cluster/apps/ai/honcho/values.yaml
+++ b/cluster/apps/ai/honcho/values.yaml
@@ -20,7 +20,7 @@ openrouterBwsId: "7ece641d-8f3e-42f6-b306-b45900a618ad" #gitleaks:allow #HONCHO_
 
 pgsql-cnpg:
   name: honchodb
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.6-standard-bookworm
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.6-system-bookworm
   instances: 2
   storage:
     size: 30Gi


### PR DESCRIPTION
## Summary

Changes `honchodb` CNPG image from `standard-bookworm` to `system-bookworm`.

The `standard-bookworm` variant includes pgvector but lacks barman-cloud tools, causing recovery to fail with `barman-cloud-check-wal-archive: executable file not found`. The `system-bookworm` image includes both barman-cloud binaries and pgvector.

Note: `system` images are deprecated upstream — long-term migration to `standard` + barman-cloud plugin tracked in TODO.

## After merging

Delete the existing CNPG cluster to force recreation with recovery bootstrap:
```
kubectl delete cluster honchodb-cnpg -n honcho
```