### PR TITLE
fix(honcho): revert to initdb bootstrap, fix serverName for future recovery

### DIFF
--- a/cluster/apps/ai/honcho/values.yaml
+++ b/cluster/apps/ai/honcho/values.yaml
@@ -32,12 +32,17 @@ pgsql-cnpg:
       memory: 512Mi
       cpu: 500m
   bootstrap:
-    recovery:
-      source: honchodb-cnpg-backup
+    initdb:
+      postInitApplicationSQL:
+        - CREATE EXTENSION IF NOT EXISTS vector
+  # Uncomment to restore from S3 backup (requires at least one successful backup to exist):
+  # bootstrap:
+  #   recovery:
+  #     source: honchodb-cnpg-backup
   externalClusters:
     - name: honchodb-cnpg-backup
       barmanObjectStore:
-        serverName: honchodb
+        serverName: honchodb-cnpg
         destinationPath: "s3://k8s-at-home-backup/cnpg/honcho"
         endpointURL: <secret:s3_endpoint>
         s3Credentials:


### PR DESCRIPTION
## Summary

- Reverts `bootstrap` from `recovery` back to `initdb` — no S3 backup exists to restore from (the original cluster used `standard-bookworm` which lacked barman-cloud, so scheduled backups silently failed)
- Keeps `externalClusters` in place with corrected `serverName: honchodb-cnpg` (cluster resource is named `honchodb-cnpg`, not `honchodb`) so recovery will work once backups accumulate with the new `system-bookworm` image
- Recovery bootstrap left as a comment for easy re-enable once a backup exists

## After merging

1. Delete the CNPG cluster to force fresh initdb: `kubectl delete cluster honchodb-cnpg -n honcho`
2. Wait for honcho-api to crash with dimension mismatch (1536 ≠ 768)
3. Fix the schema in psql:
   ```bash
   kubectl exec -n honcho honchodb-cnpg-1 -- psql -U postgres app -c \
     "ALTER TABLE documents ALTER COLUMN embedding TYPE vector(768) USING embedding::vector(768);"
   ```
4. Honcho will restart and pass startup validation