### PR TITLE
fix(hermes-agent): scale to 0 for PVC restore, make replicas configurable

### DIFF
--- a/cluster/apps/ai/hermes-agent/templates/deployment.yaml
+++ b/cluster/apps/ai/hermes-agent/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hermes-agent
   namespace: hermes-agent
 spec:
-  replicas: 1
+  replicas: {{ .Values.hermes.replicas | default 1 }}
   selector:
     matchLabels:
       app: hermes-agent

--- a/cluster/apps/ai/hermes-agent/templates/signal-deployment.yaml
+++ b/cluster/apps/ai/hermes-agent/templates/signal-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: signal-cli
   namespace: hermes-agent
 spec:
-  replicas: 1
+  replicas: {{ .Values.signalCli.replicas | default 1 }}
   selector:
     matchLabels:
       app: signal-cli

--- a/cluster/apps/ai/hermes-agent/values.yaml
+++ b/cluster/apps/ai/hermes-agent/values.yaml
@@ -1,4 +1,5 @@
 hermes:
+  replicas: 0
   image:
     repository: nousresearch/hermes-agent
     tag: "main@sha256:e1adf723aac48aff349d6a46b903d60c7c22bcc76367062bda9340319dde5605"
@@ -75,6 +76,7 @@ hermes:
 #          GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_TOKEN}
 
 signalCli:
+  replicas: 0
   image:
     repository: bbernhard/signal-cli-rest-api
     tag: "0.99@sha256:96578363477d97cb1d8da303791b2ad686b374a255fce4d78c7c6f00ef56cba8"


### PR DESCRIPTION
## Summary

- Makes `replicas` configurable via values for both `hermes-agent` and `signal-cli` deployments (defaults to 1 if not set)
- Sets `replicas: 0` for both to allow exclusive PVC access for volsync restore

## After merging

Once ArgoCD scales pods to 0, run the volsync Direct restore then set replicas back to 1 (or remove the override).