### PR TITLE
fix(pgsql-cnpg): v1.3.1 — remove barmanObjectStore wrapper from ObjectStore CR

### DIFF
--- a/charts/pgsql-cnpg/Chart.yaml
+++ b/charts/pgsql-cnpg/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: pgsql-cnpg
 type: application
-version: 1.3.0
+version: 1.3.1

--- a/charts/pgsql-cnpg/templates/cnpg.yaml
+++ b/charts/pgsql-cnpg/templates/cnpg.yaml
@@ -54,8 +54,7 @@ metadata:
   name: {{ printf "%s-objectstore" .Values.name }}
 spec:
   configuration:
-    barmanObjectStore:
-      {{- toYaml .Values.objectStore | nindent 6 }}
+    {{- toYaml .Values.objectStore | nindent 4 }}
   {{- if .Values.retentionPolicy }}
   retentionPolicy: {{ .Values.retentionPolicy }}
   {{- end }}

--- a/cluster/apps/ai/honcho/Chart.yaml
+++ b/cluster/apps/ai/honcho/Chart.yaml
@@ -5,5 +5,5 @@ type: application
 version: 1.0.0
 dependencies:
   - name: pgsql-cnpg
-    version: 1.3.0
+    version: 1.3.1
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/ai/litellm/Chart.yaml
+++ b/cluster/apps/ai/litellm/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
     version: 1.87.0
     repository: oci://ghcr.io/berriai
   - name: pgsql-cnpg
-    version: 1.3.0
+    version: 1.3.1
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/default/gitea/Chart.yaml
+++ b/cluster/apps/default/gitea/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 12.6.0
     repository: https://dl.gitea.io/charts/
   - name: pgsql-cnpg
-    version: 1.3.0
+    version: 1.3.1
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/home-automation/home-assistant/Chart.yaml
+++ b/cluster/apps/home-automation/home-assistant/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 5.0.1
     repository: https://bjw-s-labs.github.io/helm-charts
   - name: pgsql-cnpg
-    version: 1.3.0
+    version: 1.3.1
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/system/keycloak/Chart.yaml
+++ b/cluster/apps/system/keycloak/Chart.yaml
@@ -6,5 +6,5 @@ version: 2.6.0
 appVersion: "17.0.1"
 dependencies:
   - name: pgsql-cnpg
-    version: 1.3.0
+    version: 1.3.1
     repository: file://../../../../charts/pgsql-cnpg/


### PR DESCRIPTION
## Summary
- The `ObjectStore` CRD (`barmancloud.cnpg.io/v1`) expects barman config fields (`destinationPath`, `endpointURL`, `s3Credentials`, etc.) directly under `spec.configuration`, not nested under a `barmanObjectStore` sub-key
- Our chart template in v1.3.0 incorrectly wrapped them under `spec.configuration.barmanObjectStore`, causing ArgoCD SSA validation to reject the resource with `field not declared in schema`
- Bumps chart to v1.3.1 with the one-line fix; regenerates Chart.lock and tarballs for honcho and litellm

## Root cause
Wrong assumption about the ObjectStore CRD schema — verified against live cluster: `spec.configuration` has `destinationPath`, `s3Credentials`, `wal` etc. as direct children, no `barmanObjectStore` wrapper.

## Test plan
- [x] `helm template` on any of the 5 apps shows `spec.configuration.destinationPath` (not `spec.configuration.barmanObjectStore.destinationPath`)
- [x] After ArgoCD sync: `kubectl get objectstores -A` shows all 4 live clusters with status healthy