### PR TITLE
fix(pgsql-cnpg): v1.3.2 — disable boto3 flexible checksums for QNAP QuObjects

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -21,3 +21,4 @@
 
 - [Gateway and DNS architecture](reference_gateway_dns_architecture.md) — two Envoy Gateway instances; HTTPRoute annotation rules
 - [Home network hardware](reference_home_network_hardware.md) — router/NAS/RPi IPs and roles
+- [QNAP QuObjects + barman-cloud caveat](reference_qnap_s3_barman_caveat.md) — boto3 ≥1.34 checksum fix required; set AWS_REQUEST_CHECKSUM_CALCULATION=when_required on all CNPG ObjectStores

--- a/.claude/memory/reference_qnap_s3_barman_caveat.md
+++ b/.claude/memory/reference_qnap_s3_barman_caveat.md
@@ -1,0 +1,29 @@
+---
+name: reference-qnap-s3-barman-caveat
+description: QNAP QuObjects S3 store requires boto3 checksum workaround for barman-cloud-backup to succeed
+metadata:
+  type: reference
+---
+
+## QNAP QuObjects + barman-cloud: InvalidDigest workaround
+
+**S3 endpoint:** `https://s3.mmalyska.cloud` (QNAP QuObjects)
+
+**Problem:** botocore ≥ 1.34 automatically sends `x-amz-checksum-crc32` headers on multipart uploads. QNAP QuObjects rejects these with `InvalidDigest: The Content-MD5 or checksum value that you specified is not valid`.
+
+**Fix:** Add to every CNPG `ObjectStore` via `instanceSidecarConfiguration.env` in `values.yaml`:
+
+```yaml
+instanceSidecarConfiguration:
+  env:
+    - name: AWS_REQUEST_CHECKSUM_CALCULATION
+      value: when_required
+    - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+      value: when_required
+```
+
+Applied to all five CNPG clusters in `pgsql-cnpg` chart v1.3.2.
+
+**How to apply:** The `instanceSidecarConfiguration` key is a top-level sibling of `objectStore:` under `pgsql-cnpg:` in each app's `values.yaml`. The chart template renders it under `spec.instanceSidecarConfiguration` on the `ObjectStore` CR.
+
+**Why:** botocore's flexible checksums (RFC 1321 / SHA-256) were added in 1.34 and are sent by default. Pre-1.34 behaviour (checksums only when the server requires them) is restored by setting `AWS_REQUEST_CHECKSUM_CALCULATION=when_required`.

--- a/.plans/cnpg-plugin-migration/plan.md
+++ b/.plans/cnpg-plugin-migration/plan.md
@@ -140,6 +140,35 @@ pgsql-cnpg:
 
 `cloudnative-pg` (with `plugin-barman-cloud`) must be healthy before any Cluster is updated, as the plugin webhook must be registered. ArgoCD `syncWave` handles this — `cloudnative-pg` already deploys in an earlier wave.
 
+## Known Issues & Caveats
+
+### QNAP QuObjects: InvalidDigest on multipart upload (fixed in v1.3.2)
+
+**Symptom:** `barman-cloud-backup` fails with `InvalidDigest: The Content-MD5 or checksum value that you specified is not valid` on `UploadPart` and `PutObject` operations.
+
+**Root cause:** botocore ≥ 1.34 automatically sends `x-amz-checksum-crc32` headers on multipart uploads (flexible checksums). QNAP QuObjects does not implement this extension and rejects the request.
+
+**Fix:** Set these env vars on the barman-cloud sidecar via `instanceSidecarConfiguration.env` in each ObjectStore's values:
+
+```yaml
+instanceSidecarConfiguration:
+  env:
+    - name: AWS_REQUEST_CHECKSUM_CALCULATION
+      value: when_required
+    - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+      value: when_required
+```
+
+This reverts botocore to the pre-1.34 behaviour (checksums only when the server explicitly requires them). Applied to all five clusters in pgsql-cnpg chart v1.3.2.
+
+### ObjectStore CRD schema: no barmanObjectStore wrapper (fixed in v1.3.1)
+
+**Symptom:** ArgoCD SSA validation rejects ObjectStore CR with `field not declared in schema` on `.spec.configuration.barmanObjectStore`.
+
+**Root cause:** The `barmancloud.cnpg.io/v1` ObjectStore CRD places barman config fields (`destinationPath`, `s3Credentials`, etc.) directly under `spec.configuration`, not nested under a `barmanObjectStore` sub-key. Initial chart template (v1.3.0) incorrectly added an extra nesting level.
+
+**Fix:** Template updated in v1.3.1 to render `spec.configuration` with `nindent 4` directly.
+
 ## Out of Scope
 
 - Clearing old S3 backups — done separately after migration is stable.

--- a/charts/pgsql-cnpg/Chart.yaml
+++ b/charts/pgsql-cnpg/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: pgsql-cnpg
 type: application
-version: 1.3.1
+version: 1.3.2

--- a/charts/pgsql-cnpg/templates/cnpg.yaml
+++ b/charts/pgsql-cnpg/templates/cnpg.yaml
@@ -58,6 +58,10 @@ spec:
   {{- if .Values.retentionPolicy }}
   retentionPolicy: {{ .Values.retentionPolicy }}
   {{- end }}
+  {{- with .Values.instanceSidecarConfiguration }}
+  instanceSidecarConfiguration:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{ range $k, $v := .Values.scheduledBackups }}
 ---

--- a/cluster/apps/ai/honcho/Chart.yaml
+++ b/cluster/apps/ai/honcho/Chart.yaml
@@ -5,5 +5,5 @@ type: application
 version: 1.0.0
 dependencies:
   - name: pgsql-cnpg
-    version: 1.3.1
+    version: 1.3.2
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/ai/honcho/values.yaml
+++ b/cluster/apps/ai/honcho/values.yaml
@@ -58,6 +58,12 @@ pgsql-cnpg:
       secretAccessKey:
         name: honcho-secrets
         key: S3_ACCESS_SECRET_KEY
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
+      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+        value: when_required
   scheduledBackups:
     - name: honchodb-cnpg-backup
       spec:

--- a/cluster/apps/ai/litellm/Chart.yaml
+++ b/cluster/apps/ai/litellm/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
     version: 1.87.0
     repository: oci://ghcr.io/berriai
   - name: pgsql-cnpg
-    version: 1.3.1
+    version: 1.3.2
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/ai/litellm/values.yaml
+++ b/cluster/apps/ai/litellm/values.yaml
@@ -92,6 +92,12 @@ pgsql-cnpg:
       secretAccessKey:
         name: litellm-secrets
         key: S3_ACCESS_SECRET_KEY
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
+      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+        value: when_required
   scheduledBackups:
     - name: litelldb-cnpg-backup
       spec:

--- a/cluster/apps/default/gitea/Chart.yaml
+++ b/cluster/apps/default/gitea/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 12.6.0
     repository: https://dl.gitea.io/charts/
   - name: pgsql-cnpg
-    version: 1.3.1
+    version: 1.3.2
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/default/gitea/values.yaml
+++ b/cluster/apps/default/gitea/values.yaml
@@ -117,6 +117,12 @@ pgsql-cnpg:
       secretAccessKey:
         name: gitea-secrets
         key: S3_ACCESS_SECRET_KEY
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
+      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+        value: when_required
   scheduledBackups:
     - name: giteadb-cnpg-backup
       spec:

--- a/cluster/apps/home-automation/home-assistant/Chart.yaml
+++ b/cluster/apps/home-automation/home-assistant/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 5.0.1
     repository: https://bjw-s-labs.github.io/helm-charts
   - name: pgsql-cnpg
-    version: 1.3.1
+    version: 1.3.2
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/home-automation/home-assistant/values.yaml
+++ b/cluster/apps/home-automation/home-assistant/values.yaml
@@ -19,6 +19,12 @@ pgsql-cnpg:
       secretAccessKey:
         name: home-assistant-secrets
         key: S3_ACCESS_SECRET_KEY
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
+      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+        value: when_required
   scheduledBackups:
     - name: home-assistant-cnpg-backup
       spec:

--- a/cluster/apps/system/keycloak/Chart.yaml
+++ b/cluster/apps/system/keycloak/Chart.yaml
@@ -6,5 +6,5 @@ version: 2.6.0
 appVersion: "17.0.1"
 dependencies:
   - name: pgsql-cnpg
-    version: 1.3.1
+    version: 1.3.2
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/system/keycloak/values.yaml
+++ b/cluster/apps/system/keycloak/values.yaml
@@ -108,6 +108,12 @@ pgsql-cnpg:
       secretAccessKey:
         name: keycloakdb-secrets
         key: S3_ACCESS_SECRET_KEY
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
+      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+        value: when_required
   scheduledBackups:
     - name: keycloakdb-cnpg-backup
       spec:


### PR DESCRIPTION
## Summary
- QNAP QuObjects rejects barman-cloud multipart uploads with `InvalidDigest` because botocore ≥ 1.34 automatically sends `x-amz-checksum-crc32` headers that QuObjects doesn't support
- Fix: set `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` and `AWS_RESPONSE_CHECKSUM_VALIDATION=when_required` on the barman-cloud sidecar via `instanceSidecarConfiguration.env` in all 5 cluster ObjectStores
- Exposes `instanceSidecarConfiguration` in the `pgsql-cnpg` chart template (new `spec.instanceSidecarConfiguration` block on ObjectStore CR)
- Documents both migration caveats (schema fix + checksum fix) in `.plans/cnpg-plugin-migration/plan.md`
- Saves QNAP S3 caveat to project memory

## Test plan
- [x] After ArgoCD sync: delete and recreate `honchodb-manual-backup` — should reach `completed` phase
- [x] Verify `kubectl get backup -n honcho` shows `completed`