### PR TITLE
chore: increase PVC sizes for hermes-agent-data and open-webui to 5Gi

### DIFF
--- a/cluster/apps/ai/hermes-agent/templates/pvc.yaml
+++ b/cluster/apps/ai/hermes-agent/templates/pvc.yaml
@@ -8,4 +8,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 5Gi

--- a/cluster/apps/ai/open-webui/values.yaml
+++ b/cluster/apps/ai/open-webui/values.yaml
@@ -1,4 +1,6 @@
 open-webui:
+  persistence:
+    size: 5Gi
   ollama:
     enabled: false
   ingress:


### PR DESCRIPTION
## Summary

Increases PVC storage for two apps that were running low: `hermes-agent-data` was at 88% (1Gi) and `open-webui` was at 55% (2Gi).

## Changes

- **hermes-agent**: `hermes-agent-data` PVC 1Gi → 5Gi (`templates/pvc.yaml`)
- **open-webui**: `persistence.size` set to 5Gi in `values.yaml` (chart default was 2Gi)

## Files Changed

| File | Change |
|------|--------|
| `cluster/apps/ai/hermes-agent/templates/pvc.yaml` | Modified — storage 1Gi → 5Gi |
| `cluster/apps/ai/open-webui/values.yaml` | Modified — added `persistence.size: 5Gi` |

## Testing

Manifests verified via `helm template` — PVC specs render correctly with the new sizes. Ceph-block StorageClass supports `allowVolumeExpansion`, so ArgoCD sync will expand the volumes in-place.

## Related Issues

None