### PR TITLE
chore: tune resource limits for hermes, wow mysql, and honcho deriver

### DIFF
--- a/cluster/apps/ai/hermes-agent/values.yaml
+++ b/cluster/apps/ai/hermes-agent/values.yaml
@@ -8,6 +8,7 @@ hermes:
       cpu: 200m
       memory: 512Mi
     limits:
+      cpu: 1500m
       memory: 1Gi
   config:
     model:

--- a/cluster/apps/ai/honcho/values.yaml
+++ b/cluster/apps/ai/honcho/values.yaml
@@ -14,7 +14,7 @@ honcho:
         cpu: 50m
         memory: 128Mi
       limits:
-        memory: 312Mi
+        memory: 512Mi
 
 openrouterBwsId: "7ece641d-8f3e-42f6-b306-b45900a618ad" #gitleaks:allow #HONCHO_OPENROUTER_API_KEY
 

--- a/cluster/apps/games/wow/templates/mysql-statefulset.yaml
+++ b/cluster/apps/games/wow/templates/mysql-statefulset.yaml
@@ -79,7 +79,7 @@ spec:
               cpu: 200m
               memory: 512Mi
             limits:
-              memory: 1Gi
+              memory: 1536Mi
       volumes:
         - name: data
           persistentVolumeClaim:


### PR DESCRIPTION
## Summary

Addresses resource limit gaps identified in cluster audit.

## Changes

- **hermes-agent**: add CPU limit `1500m` (was unbounded; observed spike to 474m)
- **wow/mysql**: increase memory limit `1Gi → 1536Mi` (was at 83% / 830Mi used)
- **honcho/deriver**: increase memory limit `312Mi → 512Mi` (was at 76% / 238Mi used)

## Files Changed

| File | Change |
|------|--------|
| `cluster/apps/ai/hermes-agent/values.yaml` | Added `cpu: 1500m` limit |
| `cluster/apps/games/wow/templates/mysql-statefulset.yaml` | Memory limit `1Gi → 1536Mi` |
| `cluster/apps/ai/honcho/values.yaml` | Deriver memory limit `312Mi → 512Mi` |

## Testing

All manifests verified via `helm template`. Limits derived from observed actual usage plus headroom.

## Related Issues

None