### PR TITLE
feat(harbor): deploy Harbor registry for Daytona sandboxes

### DIFF
--- a/cluster/apps/core/argocd/resources/cluster-secrets-externalsecret.yaml
+++ b/cluster/apps/core/argocd/resources/cluster-secrets-externalsecret.yaml
@@ -48,3 +48,39 @@ spec:
     - secretKey: oidc-admin-user
       remoteRef:
         key: "e4f38977-0c3f-4dab-809f-b449015a3419" #gitleaks:allow #CLUSTER_SECRET_OIDC_ADMIN_USER
+    - secretKey: harbor-admin-password
+      remoteRef:
+        key: "464759da-0179-4d98-9d7b-b45d00ea365c" #gitleaks:allow #HARBOR_ADMIN_PASSWORD
+    - secretKey: daytona-ssh-host-private-key
+      remoteRef:
+        key: "3d5193cf-c462-4834-8a3f-b45d00eaa179" #gitleaks:allow #DAYTONA_SSH_HOST_PRIVATE_KEY
+    - secretKey: daytona-ssh-host-public-key
+      remoteRef:
+        key: "3d123e29-c379-495d-a9a8-b45d00eac204" #gitleaks:allow #DAYTONA_SSH_HOST_PUBLIC_KEY
+    - secretKey: daytona-ssh-client-private-key
+      remoteRef:
+        key: "d2f3d834-c81a-4a57-b15c-b45d00eaf509" #gitleaks:allow #DAYTONA_SSH_CLIENT_PRIVATE_KEY
+    - secretKey: daytona-ssh-client-public-key
+      remoteRef:
+        key: "a74f5f4a-711c-4cb3-8c96-b45d00eb14ed" #gitleaks:allow #DAYTONA_SSH_CLIENT_PUBLIC_KEY
+    - secretKey: daytona-encryption-key
+      remoteRef:
+        key: "b84d234d-f2e7-4ce5-93bc-b45d00eb31dc" #gitleaks:allow #DAYTONA_ENCRYPTION_KEY
+    - secretKey: daytona-encryption-salt
+      remoteRef:
+        key: "1ce32524-b66d-46c1-8cf2-b45d00eb46d6" #gitleaks:allow #DAYTONA_ENCRYPTION_SALT
+    - secretKey: daytona-runner-manager-api-key
+      remoteRef:
+        key: "3bad818c-c445-4777-8395-b45d00eb6415" #gitleaks:allow #DAYTONA_RUNNER_MANAGER_API_KEY
+    - secretKey: daytona-runner-api-token
+      remoteRef:
+        key: "b5f42541-8b64-4256-b487-b45d00eb7ad2" #gitleaks:allow #DAYTONA_RUNNER_API_TOKEN
+    - secretKey: daytona-system-api-token
+      remoteRef:
+        key: "a7f6b0c8-da80-4cd8-be35-b45d00eb9b61" #gitleaks:allow #DAYTONA_SYSTEM_API_TOKEN
+    - secretKey: daytona-ssh-gateway-api-key
+      remoteRef:
+        key: "4c7e4702-2e53-4c5a-83ec-b45d00ebb68b" #gitleaks:allow #DAYTONA_SSH_GATEWAY_API_KEY
+    - secretKey: daytona-db-password
+      remoteRef:
+        key: "c198e0e6-e255-41a3-89f1-b45d00ebd7f1" #gitleaks:allow #DAYTONA_DB_PASSWORD

--- a/cluster/apps/default/harbor/Chart.yaml
+++ b/cluster/apps/default/harbor/Chart.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v2
+name: harbor
+type: application
+version: 1.0.0
+dependencies:
+  - name: harbor
+    version: 1.19.1
+    repository: https://helm.goharbor.io
+  - name: pgsql-cnpg
+    version: 1.3.2
+    repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/default/harbor/app-config.yaml
+++ b/cluster/apps/default/harbor/app-config.yaml
@@ -1,0 +1,11 @@
+---
+enabled: "true"
+namespace: harbor
+syncPolicy:
+  enabled: true
+  selfHeal: true
+  prune: false
+plugin:
+  env:
+    - name: SECRET_PROVIDER
+      value: cluster-secrets

--- a/cluster/apps/default/harbor/templates/httproute.yaml
+++ b/cluster/apps/default/harbor/templates/httproute.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: harbor
+  annotations:
+    external-dns.alpha.kubernetes.io/controller: dns-controller
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: envoy-gateway
+      sectionName: https
+  hostnames:
+    - harbor.<secret:private-domain>
+  rules:
+    - backendRefs:
+        - name: harbor
+          port: 80

--- a/cluster/apps/default/harbor/values.yaml
+++ b/cluster/apps/default/harbor/values.yaml
@@ -1,0 +1,56 @@
+harbor:
+  expose:
+    type: clusterIP
+    tls:
+      enabled: false
+  externalURL: https://harbor.<secret:private-domain>
+
+  # Admin password from cluster-secrets (substituted before Helm renders)
+  harborAdminPassword: <secret:harbor-admin-password>
+
+  persistence:
+    enabled: true
+    persistentVolumeClaim:
+      registry:
+        storageClass: ceph-block
+        size: 200Gi
+      jobservice:
+        jobLog:
+          storageClass: ceph-block
+          size: 5Gi
+      database:
+        storageClass: ceph-block
+        size: 2Gi
+      redis:
+        storageClass: ceph-block
+        size: 2Gi
+      trivy:
+        storageClass: ceph-block
+        size: 5Gi
+
+  database:
+    type: external
+    external:
+      host: harbordb-cnpg-rw
+      port: "5432"
+      username: app
+      coreDatabase: app
+      existingSecret: harbordb-cnpg-app
+      sslmode: require
+
+  redis:
+    type: internal
+
+  trivy:
+    enabled: false
+
+  notary:
+    server:
+      enabled: false
+    signer:
+      enabled: false
+
+pgsql-cnpg:
+  name: harbordb
+  storage:
+    size: 5Gi

--- a/provision/talos/templates/controlplane.yaml
+++ b/provision/talos/templates/controlplane.yaml
@@ -69,6 +69,7 @@ machine:
   nodeLabels:
     topology.kubernetes.io/region: home
     topology.kubernetes.io/zone: m
+    daytona-sandbox-c: "true"
 cluster:
   id: ${TALHELPER_CLUSTERNAME}
   secret: ${TALHELPER_CLUSTERSECRET}


### PR DESCRIPTION
## Summary

Sets up Harbor as a private OCI registry for Daytona sandbox snapshots. Part of the Daytona installation series.

## Changes

- `provision/talos/templates/controlplane.yaml` — add `daytona-sandbox-c: "true"` node label to all control-plane nodes
- `cluster/apps/core/argocd/resources/cluster-secrets-externalsecret.yaml` — add Harbor admin password + 11 Daytona secret entries
- `cluster/apps/default/harbor/` — new ArgoCD app (Harbor 1.19.1, CNPG-backed PostgreSQL, Ceph RBD storage, Envoy Gateway HTTPRoute)

## Post-merge manual steps

After ArgoCD syncs Harbor to `Healthy/Synced`:

1. Apply Talos config to control-plane nodes (node label):
   ```
   talosctl apply-config -n 192.168.48.2 -f provision/talos/clusterconfig/home-mc1.yaml
   talosctl apply-config -n 192.168.48.3 -f provision/talos/clusterconfig/home-mc2.yaml
   talosctl apply-config -n 192.168.48.4 -f provision/talos/clusterconfig/home-mc3.yaml
   ```

2. Create Harbor project `daytona` and robot account (see plan Task 7 in `docs/superpowers/plans/2026-06-02-daytona-installation.md`)

3. Store robot credentials in Bitwarden → add UUIDs to cluster-secrets (follow-up PR)

## Related

Design spec: `docs/superpowers/specs/2026-06-02-daytona-installation-design.md`