### PR TITLE
feat(daytona): deploy Daytona sandbox platform

### DIFF
--- a/cluster/apps/ai/daytona/Chart.yaml
+++ b/cluster/apps/ai/daytona/Chart.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v2
+name: daytona
+type: application
+version: 1.0.0
+dependencies:
+  - name: daytona
+    version: 0.0.25
+    repository: https://daytonaio.github.io/helm-charts
+  - name: pgsql-cnpg
+    version: 1.3.2
+    repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/ai/daytona/app-config.yaml
+++ b/cluster/apps/ai/daytona/app-config.yaml
@@ -1,0 +1,10 @@
+- enabled: "true"
+  namespace: daytona
+  syncPolicy:
+    enabled: true
+    selfHeal: true
+    prune: false
+  plugin:
+    env:
+      - name: SECRET_PROVIDER
+        value: cluster-secrets

--- a/cluster/apps/ai/daytona/templates/daytonadb-init-externalsecret.yaml
+++ b/cluster/apps/ai/daytona/templates/daytonadb-init-externalsecret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: daytonadb-init-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  refreshInterval: 1h
+  target:
+    name: daytonadb-init-secret
+    creationPolicy: Owner
+    template:
+      data:
+        username: app
+  data:
+    - secretKey: password
+      remoteRef:
+        key: "c198e0e6-e255-41a3-89f1-b45d00ebd7f1" #gitleaks:allow #DAYTONA_DB_PASSWORD

--- a/cluster/apps/ai/daytona/templates/httproute-api.yaml
+++ b/cluster/apps/ai/daytona/templates/httproute-api.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: daytona-api
+  annotations:
+    external-dns.alpha.kubernetes.io/controller: dns-controller
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: envoy-gateway
+      sectionName: https
+  hostnames:
+    - daytona.<secret:private-domain>
+  rules:
+    - backendRefs:
+        - name: daytona-api
+          port: 3000

--- a/cluster/apps/ai/daytona/templates/httproute-proxy.yaml
+++ b/cluster/apps/ai/daytona/templates/httproute-proxy.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: daytona-proxy
+  annotations:
+    external-dns.alpha.kubernetes.io/controller: dns-controller
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: envoy-gateway
+      sectionName: https
+  hostnames:
+    - "*.daytona.<secret:private-domain>"
+  rules:
+    - backendRefs:
+        - name: daytona-proxy
+          port: 4000

--- a/cluster/apps/ai/daytona/templates/s3-externalsecret.yaml
+++ b/cluster/apps/ai/daytona/templates/s3-externalsecret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: daytona-s3-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  refreshInterval: 1h
+  target:
+    name: daytona-s3-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: S3_ACCESS_KEY_ID
+      remoteRef:
+        key: "e00e1e38-ae37-479a-8b46-b409016331eb" #gitleaks:allow #S3_ACCESS_KEY
+    - secretKey: S3_ACCESS_SECRET_KEY
+      remoteRef:
+        key: "4d5a418c-82ed-4b8e-bfbf-b40901634ea4" #gitleaks:allow #S3_SECRET_KEY

--- a/cluster/apps/ai/daytona/values.yaml
+++ b/cluster/apps/ai/daytona/values.yaml
@@ -1,0 +1,164 @@
+daytona:
+  baseDomain: daytona.<secret:private-domain>
+
+  services:
+    api:
+      env:
+        ENVIRONMENT: "production"
+        PORT: "3000"
+
+        # OIDC — Keycloak home realm (Dex subchart disabled)
+        OIDC_CLIENT_ID: "daytona"
+        OIDC_ISSUER_BASE_URL: "https://l.<secret:private-domain>/realms/home"
+        PUBLIC_OIDC_DOMAIN: "https://l.<secret:private-domain>"
+        OIDC_AUDIENCE: "daytona"
+        OIDC_CLIENT_SECRET: <secret:daytona-oidc-client-secret>
+        SKIP_USER_EMAIL_VERIFICATION: "true"
+
+        # Encryption
+        ENCRYPTION_KEY: <secret:daytona-encryption-key>
+        ENCRYPTION_SALT: <secret:daytona-encryption-salt>
+
+        DRAINING_MODE: "archive"
+        DRAINING_FORCE: "true"
+
+        DEFAULT_SNAPSHOT_IMAGE_NAME: "daytonaio/sandbox:0.5.1-slim"
+        DEFAULT_SNAPSHOT_NAME: "default-snapshot"
+
+        RUNNER_MANAGER_API_KEY: <secret:daytona-runner-manager-api-key>
+
+        # Harbor registry (deployed as separate app in default namespace)
+        TRANSIENT_REGISTRY_URL: "harbor.default.svc.cluster.local"
+        TRANSIENT_REGISTRY_ADMIN: <secret:daytona-harbor-robot-name>
+        TRANSIENT_REGISTRY_PASSWORD: <secret:daytona-harbor-robot-secret>
+        TRANSIENT_REGISTRY_PROJECT_ID: "daytona"
+        INTERNAL_REGISTRY_URL: "harbor.default.svc.cluster.local"
+        INTERNAL_REGISTRY_ADMIN: <secret:daytona-harbor-robot-name>
+        INTERNAL_REGISTRY_PASSWORD: <secret:daytona-harbor-robot-secret>
+        INTERNAL_REGISTRY_PROJECT_ID: "daytona"
+
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+
+    sshGateway:
+      enabled: true
+      service:
+        type: LoadBalancer
+        port: 2222
+        annotations:
+          io.cilium/lb-ipam-pool: daytona-pool
+      apiKey: <secret:daytona-ssh-gateway-api-key>
+      sshKeys:
+        privHostSSHKey: <secret:daytona-ssh-host-private-key>
+        pubHostSSHKey: <secret:daytona-ssh-host-public-key>
+        privClientSSHKey: <secret:daytona-ssh-client-private-key>
+        pubClientSSHKey: <secret:daytona-ssh-client-public-key>
+
+    runnermanager:
+      env:
+        API_TOKEN: <secret:daytona-runner-manager-api-key>
+
+    runner:
+      env:
+        API_TOKEN: <secret:daytona-runner-api-token>
+        SYSTEM_API_TOKEN: <secret:daytona-system-api-token>
+        SSH_PUBLIC_KEY: <secret:daytona-ssh-client-public-key>
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: daytona-sandbox-c
+                    operator: In
+                    values:
+                      - "true"
+      resources:
+        limits:
+          cpu: 2000m
+          memory: 4Gi
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      dockerInstaller:
+        enabled: true
+        xfsStorageSize: "50G"
+
+  # Disabled subcharts
+  postgresql:
+    enabled: false
+
+  dex:
+    enabled: false
+
+  harbor:
+    enabled: false
+
+  minio:
+    enabled: false
+
+  pgadmin4:
+    enabled: false
+
+  # Bundled Redis — isolated
+  redis:
+    enabled: true
+    auth:
+      enabled: false
+    persistence:
+      enabled: true
+      storageClass: ceph-block
+      size: 1Gi
+    replica:
+      replicaCount: 0
+
+  # External CNPG database
+  externalDatabase:
+    host: daytonadb-cnpg-rw
+    port: 5432
+    name: app
+    user: app
+    enableTLS: true
+    allowSelfSignedCert: true
+    password: <secret:daytona-db-password>
+
+pgsql-cnpg:
+  name: daytonadb
+  instances: 2
+  storage:
+    size: 5Gi
+  monitoring:
+    enablePodMonitor: true
+  retentionPolicy: "10d"
+  objectStore:
+    destinationPath: "s3://k8s-at-home-backup/cnpg/daytona"
+    endpointURL: <secret:s3_endpoint>
+    s3Credentials:
+      accessKeyId:
+        name: daytona-s3-secret
+        key: S3_ACCESS_KEY_ID
+      secretAccessKey:
+        name: daytona-s3-secret
+        key: S3_ACCESS_SECRET_KEY
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
+      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+        value: when_required
+  scheduledBackups:
+    - name: daytonadb-cnpg-backup
+      spec:
+        immediate: true
+        schedule: "5 0 0 * * *"
+        backupOwnerReference: self
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+      secret:
+        name: daytonadb-init-secret

--- a/cluster/apps/core/argocd/resources/cluster-secrets-externalsecret.yaml
+++ b/cluster/apps/core/argocd/resources/cluster-secrets-externalsecret.yaml
@@ -90,3 +90,6 @@ spec:
     - secretKey: daytona-harbor-robot-secret
       remoteRef:
         key: "98307436-f8f7-4f37-bc04-b45d00f635f6" #gitleaks:allow #HARBOR_ROBOT_SECRET
+    - secretKey: daytona-oidc-client-secret
+      remoteRef:
+        key: "84c913e2-e00c-494f-9391-b45d00fad1fa" #gitleaks:allow #DAYTONA_OIDC_CLIENT_SECRET


### PR DESCRIPTION
## Summary

Deploys Daytona sandbox platform to the cluster, enabling isolated sandboxed environments for Hermes agent profiles and SSH-accessible dev environments.

## Changes

- `cluster/apps/core/argocd/resources/cluster-secrets-externalsecret.yaml` — add Daytona OIDC client secret
- `cluster/apps/ai/daytona/` — new ArgoCD app:
  - Daytona v0.0.25 + pgsql-cnpg v1.3.2
  - Keycloak `home` realm as OIDC provider (Dex disabled)
  - Harbor at `harbor.default.svc.cluster.local` as snapshot registry (Harbor subchart disabled)
  - Ceph RBD Redis (1Gi)
  - CNPG cluster `daytonadb` (2 instances, barman-cloud S3 backups to QNAP, bootstrap via `daytonadb-init-secret`)
  - SSH Gateway: LoadBalancer from Cilium `daytona-pool` (192.168.48.51–70), port 2222
  - Wildcard HTTPRoute `*.daytona.<domain>` → proxy, `daytona.<domain>` → API — both via `envoy-internal`
  - Runner targets nodes labeled `daytona-sandbox-c: "true"` (all 3 control-plane nodes)

## Post-merge steps (Task 12)

After ArgoCD syncs to `Healthy/Synced`:

1. Verify all pods running: `kubectl -n daytona get pods`
2. Check SSH Gateway IP is from daytona-pool: `kubectl -n daytona get svc daytona-ssh-gateway`
3. Open `https://daytona.<domain>` → should redirect to Keycloak login
4. Verify runner registered in API logs: `kubectl -n daytona logs deploy/daytona-api | grep -i runner`
5. Test SSH gateway: `nc -zv <ssh-gw-ip> 2222`
6. Create first sandbox from dashboard using `ubuntu:22.04`

## Related

- Design spec: `docs/superpowers/specs/2026-06-02-daytona-installation-design.md`
- Implementation plan: `docs/superpowers/plans/2026-06-02-daytona-installation.md`
- Depends on: #4049 (Cilium pool), #4050 (Harbor registry), #4051 (Harbor CNPG fix) — all merged