### PR TITLE
fix(lint): suppress secretlint false positive in Coder spec doc

### DIFF
--- a/docs/superpowers/specs/2026-06-03-coder-sandbox-design.md
+++ b/docs/superpowers/specs/2026-06-03-coder-sandbox-design.md
@@ -78,6 +78,7 @@ The two paths are independent — Coder server downtime does not break active di
 
 **Key environment variables (from ExternalSecret → K8s Secret):**
 
+<!-- secretlint-disable -->
 ```
 CODER_ACCESS_URL          = https://coder.<private-domain>
 CODER_PG_CONNECTION_URL   = postgres://app:<pw>@coderdb-cnpg-rw/app?sslmode=require
@@ -86,6 +87,7 @@ CODER_OIDC_CLIENT_ID      = coder
 CODER_OIDC_CLIENT_SECRET  = <from Bitwarden>
 CODER_OIDC_EMAIL_DOMAIN   = gmail.com
 ```
+<!-- secretlint-enable -->
 
 **HTTPRoute:** `coder.<private-domain>` → Coder service port 80, private Envoy Gateway. No `oauth2-proxy` wrapper — Coder handles its own auth.
 


### PR DESCRIPTION
## Summary

- The Coder sandbox design spec (`docs/superpowers/specs/2026-06-03-coder-sandbox-design.md`) contains an example PostgreSQL connection string (`postgres://app:<pw>@...`) in a code block
- Secretlint's `PostgreSQLConnection` rule treats it as a real credential, causing the Lint check to fail on **every** Renovate PR (since the file exists on `main`)
- Added `<!-- secretlint-disable -->` / `<!-- secretlint-enable -->` HTML comments around the code block to suppress the false positive

## Test plan

- [ ] Lint check passes on this PR
- [ ] After merging, existing Renovate PRs should be re-tested and their Lint checks should pass