### PR TITLE
feat(smartmon-exporter): add NVMe SMART collection for all nodes

### DIFF
--- a/cluster/apps/system/smartmon-exporter/values.yaml
+++ b/cluster/apps/system/smartmon-exporter/values.yaml
@@ -2,6 +2,7 @@ prometheus-smartctl-exporter:
   config:
     devices:
       - /dev/sda
+      - /dev/nvme0n1
 
   serviceMonitor:
     enabled: true
@@ -24,3 +25,23 @@ prometheus-smartctl-exporter:
     limits:
       cpu: 50m
       memory: 64Mi
+
+  extraInstances:
+    - config:
+        devices:
+          - /dev/nvme0n1
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values: [nv1]
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 50m
+          memory: 64Mi


### PR DESCRIPTION
## Summary

- Adds `/dev/nvme0n1` to smartctl-exporter devices on mc1/mc2/mc3 (alongside existing `/dev/sda`)
- Adds a second DaemonSet instance targeting `nv1` (nvme0n1 only — no SATA drive)
- Enables full SMART health metrics for all NVMe drives via `smartctl_device_*` metrics

## Details

Two DaemonSets rendered:
- `smartmon-exporter-prometheus-smartctl-exporter-0` — mc1/mc2/mc3, devices: sda + nvme0n1
- `smartmon-exporter-prometheus-smartctl-exporter-1` — nv1, devices: nvme0n1 only

## Background

`node-exporter --collector.nvme` only emits identity metrics (`node_nvme_info`) on Talos nodes due to ioctl restrictions for unprivileged containers. The existing privileged smartctl-exporter DaemonSet already bypasses this for SATA — extending it to NVMe should work via the same path.

## Test plan

- [ ] After ArgoCD sync, verify 4 pods running: 3 on mc nodes + 1 on nv1
- [ ] Verify `smartctl_device_smart_status{device="nvme0n1"}` appears in Prometheus for all 4 nodes
- [ ] Verify `smartctl_device_temperature{device="nvme0n1"}` has values in expected range (30–60°C)
- [ ] Confirm no errors in pod logs (`kubectl logs -n monitoring -l app.kubernetes.io/name=prometheus-smartctl-exporter`)