### PR TITLE
fix(hermes-agent): add --replace flag to prevent gateway PID collision on restart

### DIFF
--- a/cluster/apps/ai/hermes-agent/templates/deployment.yaml
+++ b/cluster/apps/ai/hermes-agent/templates/deployment.yaml
@@ -147,6 +147,7 @@ spec:
           args:
             - gateway
             - run
+            - --replace
           lifecycle:
             postStart:
               exec:


### PR DESCRIPTION
## Summary

Adds `--replace` to the `hermes gateway run` args so that any stale PID file left on the persistent volume after a container restart is automatically cleared before the new gateway process starts. Without this flag, on container restart s6-supervise would start a new gateway instance that detected the old PID file and exited with *"Another gateway instance started during our startup"*, causing a crash loop.

## Changes

- `cluster/apps/ai/hermes-agent/templates/deployment.yaml`: add `--replace` arg to hermes-agent container

## Files Changed

| File | Change |
|------|--------|
| `cluster/apps/ai/hermes-agent/templates/deployment.yaml` | Modified |

## Testing

The pod has been stable for 9h since its last clean start. The `--replace` flag is documented in the gateway's own error output (`hermes gateway run --replace` to auto-replace). The fix will take effect on the next pod restart/rollout via ArgoCD.

## Related Issues

Identified in cluster operational audit 2026-06-11.