### PR TITLE
fix(prometheus-stack): disable kubeProxy scrape target on Cilium cluster

### DIFF
--- a/cluster/apps/system/prometheus-stack/values.yaml
+++ b/cluster/apps/system/prometheus-stack/values.yaml
@@ -4,7 +4,7 @@ kube-prometheus-stack:
   kubeEtcd:
     enabled: true
   kubeProxy:
-    enabled: true
+    enabled: false
   kubeScheduler:
     enabled: true
   grafana:


### PR DESCRIPTION
## Summary

Sets `kubeProxy.enabled: false` in the kube-prometheus-stack values. On this Talos + Cilium cluster kube-proxy is not running — Cilium handles all proxy functionality. The headless `prometheus-stack-kube-prom-kube-proxy` service has zero endpoints, so the `KubeProxyDown` alert has been firing as a false positive for 7+ weeks.

## Changes

- `cluster/apps/system/prometheus-stack/values.yaml`: set `kubeProxy.enabled: false`

## Verification

Confirmed no kube-proxy pods or DaemonSet exist in the cluster. The `metrics-proxy` DaemonSet in kube-system is an unrelated HAProxy instance. The scrape service endpoint has no addresses.

## Related Issues

Identified in cluster operational audit 2026-06-11 (action item #2).