### PR TITLE
chore(gitea): disable app, data backed up via volsync

### DIFF
--- a/cluster/apps/default/gitea/app-config.yaml
+++ b/cluster/apps/default/gitea/app-config.yaml
@@ -1,4 +1,4 @@
-- enabled: "true"
+- enabled: "false"
   namespace: gitea
   syncPolicy:
     enabled: true


### PR DESCRIPTION
## Summary

Sets `enabled: "false"` for the gitea ArgoCD Application. The deployment has been at `replicaCount: 0` for 380+ days — the app is not in use. Volsync is actively backing up `gitea-data` PVC every 12 hours (last run today), with daily/weekly/monthly retention, so data is safe to restore if needed.

## Behaviour after merge

- ArgoCD will remove the gitea Application CR
- Existing resources (valkey, CNPG) remain running as orphans (`prune: false`) until manually cleaned up
- To restore: uncomment the `ReplicationDestination` in `templates/volsync.yaml`, re-enable, and set `replicaCount: 1`

## Changes

- `cluster/apps/default/gitea/app-config.yaml`: `enabled: "true"` → `"false"`

## Related Issues

Identified in cluster operational audit 2026-06-11 (action item #3).