### PR TITLE
fix(bookorbit): add init container to wait for CNPG before startup

### DIFF
--- a/cluster/apps/default/bookorbit/values.yaml
+++ b/cluster/apps/default/bookorbit/values.yaml
@@ -7,6 +7,15 @@ app-template:
           runAsGroup: 1001
           fsGroup: 1001
           fsGroupChangePolicy: OnRootMismatch
+      initContainers:
+        wait-db:
+          image:
+            repository: busybox
+            tag: latest
+          command:
+            - sh
+            - -c
+            - until nc -z bookorbdb-cnpg-rw 5432; do sleep 2; done
       containers:
         app:
           image:


### PR DESCRIPTION
## Summary

Adds a `wait-db` init container that polls `bookorbdb-cnpg-rw:5432` with `nc -z` until the database accepts connections. This prevents bookorbit from crash-looping when CNPG restarts before bookorbit — the app runs DB migrations at startup and exits with `EHOSTUNREACH` if PostgreSQL isn't ready, causing unnecessary restart churn.

## Root cause

During a CNPG maintenance restart (~22h prior to audit), bookorbit started before the RW service had endpoints. The migration runner (`runMigrations`) failed immediately with `connect EHOSTUNREACH 10.105.4.10:5432`. Kubernetes restarted it 3× via backoff until CNPG was ready.

## Changes

- `cluster/apps/default/bookorbit/values.yaml`: add `wait-db` init container under `controllers.bookorbit.initContainers`

## Related Issues

Identified in cluster operational audit 2026-06-11 (action item #4).