### PR TITLE
fix(talos): add EthernetConfig to increase e1000e NIC ring buffer to 4096

### DIFF
--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -151,6 +151,7 @@ tasks:
             --patch @nodes/{{.ITEM}}.yaml \
             -o /tmp/talos-patched.yaml
           envsubst < templates/extension-nut-client.yaml >> /tmp/talos-patched.yaml
+          cat templates/ethernet-rings.yaml >> /tmp/talos-patched.yaml
           mv /tmp/talos-patched.yaml clusterconfig/home-{{.ITEM}}.yaml
       - for:
           var: WORKER_LIST

--- a/provision/talos/templates/ethernet-rings.yaml
+++ b/provision/talos/templates/ethernet-rings.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1alpha1
+kind: EthernetConfig
+name: eth0
+rings:
+  rx: 4096
+  tx: 4096


### PR DESCRIPTION
## Summary

Adds an `EthernetConfig` document to all controlplane node machine configs (mc1/mc2/mc3) that raises the e1000e NIC RX/TX ring buffer from the default 256 descriptors to 4096. This reduces packet drops during Ceph replication/scrub traffic bursts.

## Background

Audit identified bursty `CephNodeNetworkPacketDrops` on mc2/mc3 (now all 3 nodes). Investigation showed:
- NIC: Intel e1000e (I219-LM) on all Lenovo M720q nodes
- Default ring buffer: 256 RX descriptors — overflows during Ceph bursts
- Drops are transient (0.0000% of total traffic), Ceph HEALTH_OK, but worsening over time

`EthernetConfig` is a standalone Talos machine config document type (separate from `machine.network.interfaces`), appended during `task talos:generate` alongside the existing `ExtensionServiceConfig` for nut-client.

## Changes

- `provision/talos/templates/ethernet-rings.yaml`: new EthernetConfig document (`rx: 4096`, `tx: 4096`)
- `.taskfiles/talos/Taskfile.yaml`: append ethernet-rings template for all controlplane nodes during generate

## Applying

After merge, run `task talos:generate` then `task talos:apply N=mc1` (and mc2, mc3) to push the config. No reboot required — ring buffer changes are applied live by Talos.

## Related Issues

Identified in cluster operational audit 2026-06-11 (action item #5).