### PR TITLE
fix(home-automation): right-size whisper/piper/openwakeword CPU requests

### DIFF
--- a/.claude/skills/k8s-wait-for-db/SKILL.md
+++ b/.claude/skills/k8s-wait-for-db/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: k8s-wait-for-db
+description: >
+  Init container pattern that blocks app startup until a database service accepts
+  connections. Use when an app crash-loops because it runs DB migrations at
+  startup before the database pod is ready.
+when_to_use: >
+  Trigger phrases: "crash loop on startup", "EHOSTUNREACH database", "migration fails",
+  "connection refused on start", "app starts before db", "startup ordering",
+  "CNPG restart", "db not ready".
+---
+
+# Wait-for-DB Init Container
+
+## Problem
+
+Apps that run DB migrations at startup exit with `EHOSTUNREACH` or `connection refused`
+when Kubernetes schedules them before the database is ready (e.g. after a CNPG failover
+or maintenance restart). The app crash-loops until the DB comes up.
+
+## Solution
+
+Add a `wait-db` init container that polls the DB service with `nc -z` before the app starts.
+
+### bjw-s app-template style
+
+```yaml
+controllers:
+  app:
+    initContainers:
+      wait-db:
+        image:
+          repository: busybox
+          tag: latest
+        command:
+          - sh
+          - -c
+          - until nc -z <db-service> <port>; do sleep 2; done
+    containers:
+      app:
+        ...
+```
+
+### Plain Kubernetes Deployment
+
+```yaml
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-db
+          image: busybox:latest
+          command: ['sh', '-c', 'until nc -z <db-service> <port>; do sleep 2; done']
+      containers:
+        - name: app
+          ...
+```
+
+## CNPG Service Names
+
+CloudNative-PG creates predictable service names:
+
+| Service | Purpose |
+|---------|---------|
+| `<cluster>-cnpg-rw` | Primary (read-write) — use this for apps |
+| `<cluster>-cnpg-ro` | Read-only replicas |
+| `<cluster>-cnpg-r` | Any instance |
+
+Example for a cluster named `bookorbdb`:
+```sh
+until nc -z bookorbdb-cnpg-rw 5432; do sleep 2; done
+```
+
+## Why Not a Startup Probe?
+
+Startup probes fire **after** the container starts. If the app crashes during `CMD`
+execution (before any probe kicks in), Kubernetes restarts it via the default restart
+policy. An init container prevents the main container from starting at all until the
+condition is met — cleaner and avoids crash-loop backoff delays.

--- a/.claude/skills/talos-ethernet-config/SKILL.md
+++ b/.claude/skills/talos-ethernet-config/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: talos-ethernet-config
+description: >
+  EthernetConfig is a separate top-level Talos machine config document, not a
+  nested field under machine.network.interfaces. Use when configuring NIC ring
+  buffers, channels, or features on Talos nodes.
+when_to_use: >
+  Trigger phrases: "ring buffer", "NIC tuning", "ethtool", "EthernetConfig",
+  "packet drops", "e1000e", "NIC configuration", "ethernet rings".
+---
+
+# Talos EthernetConfig
+
+## The Trap
+
+`ethernetConfig` does **not** nest under `machine.network.interfaces[]`. This fails:
+
+```yaml
+# WRONG — causes "unknown keys found during decoding"
+machine:
+  network:
+    interfaces:
+      - interface: eth0
+        ethernetConfig:       # ← does not exist here
+          rings:
+            rx: 4096
+```
+
+## Correct Format
+
+`EthernetConfig` is a **standalone document** appended after the main `v1alpha1` doc:
+
+```yaml
+---
+apiVersion: v1alpha1
+kind: EthernetConfig
+name: eth0
+rings:
+  rx: 4096
+  tx: 4096
+```
+
+## Repo Pattern
+
+Add a template file and append it in the `generate` task — same pattern as `extension-nut-client.yaml`:
+
+1. Create `provision/talos/templates/ethernet-rings.yaml`:
+
+```yaml
+---
+apiVersion: v1alpha1
+kind: EthernetConfig
+name: eth0
+rings:
+  rx: 4096
+  tx: 4096
+```
+
+2. Append it in `.taskfiles/talos/Taskfile.yaml` for controlplane nodes:
+
+```bash
+envsubst < templates/extension-nut-client.yaml >> /tmp/talos-patched.yaml
+cat templates/ethernet-rings.yaml >> /tmp/talos-patched.yaml   # ← add this line
+mv /tmp/talos-patched.yaml clusterconfig/home-{{.ITEM}}.yaml
+```
+
+## Check Supported Values First
+
+Before setting ring sizes, verify hardware limits:
+
+```bash
+TALOSCONFIG=provision/talos/clusterconfig/talosconfig
+talosctl -n <node-ip> --talosconfig $TALOSCONFIG get ethernetstatus eth0 -o yaml \
+  | grep -A 6 "rings:"
+```
+
+Look for `rx-max` and `tx-max`. The Intel I219-LM (e1000e) on Lenovo M720q supports `rx-max: 4096, tx-max: 4096` with a default of 256.
+
+## Other EthernetConfig Fields
+
+| Field | ethtool equivalent | Purpose |
+|-------|-------------------|---------|
+| `rings.rx` / `rings.tx` | `ethtool -G` | Ring buffer size |
+| `channels` | `ethtool -L` | RX/TX channel count |
+| `features` | `ethtool -K` | Driver feature flags |
+| `wakeOnLAN` | `ethtool -s wol` | Wake-on-LAN modes |

--- a/cluster/apps/home-automation/openwakeword/values.yaml
+++ b/cluster/apps/home-automation/openwakeword/values.yaml
@@ -13,7 +13,7 @@ app-template:
             - /custom
           resources:
             requests:
-              cpu: 500m
+              cpu: 50m
               memory: 200Mi
             limits:
               cpu: 2000m

--- a/cluster/apps/home-automation/piper/values.yaml
+++ b/cluster/apps/home-automation/piper/values.yaml
@@ -14,7 +14,7 @@ app-template:
             - --update-voices
           resources:
             requests:
-              cpu: 1000m
+              cpu: 100m
               memory: 1Gi
             limits:
               cpu: 4000m

--- a/cluster/apps/home-automation/whisper/values.yaml
+++ b/cluster/apps/home-automation/whisper/values.yaml
@@ -19,7 +19,7 @@ app-template:
             HF_HUB_CACHE: "/model-cache"
           resources:
             requests:
-              cpu: 1000m
+              cpu: 100m
               memory: 1Gi
             limits:
               cpu: 4000m


### PR DESCRIPTION
## Summary

Reduces CPU requests for the three Wyoming voice pipeline services from 10-20× their observed usage. Actual utilization is <5m for whisper/piper and <2m for openwakeword; prior requests were 1000m/1000m/500m.

## Changes

| App | CPU request before | CPU request after | Actual usage |
|-----|-------------------|-------------------|--------------|
| whisper | 1000m | 100m | <5m |
| piper | 1000m | 100m | <5m |
| openwakeword | 500m | 50m | <2m |

CPU limits are unchanged (4000m/4000m/2000m) so burst transcription capacity is preserved.

## Testing

- `helm template` rendered correctly for all three apps
- CPU limits unchanged; only requests reduced