### PR TITLE
feat(prometheus): enable DRM and Tegra thermal zone collectors

### DIFF
--- a/cluster/apps/system/prometheus-stack/values.yaml
+++ b/cluster/apps/system/prometheus-stack/values.yaml
@@ -183,6 +183,9 @@ kube-prometheus-stack:
     extraArgs:
       - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
       - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
-      # disable thermal zone for stuck exporter on jetson platform REF: https://github.com/prometheus/node_exporter/issues/3071
-      - --no-collector.thermal_zone
+      # thermal_zone: filter to known-good Tegra (Orin) zones; excludes gpu-thermal which returns empty on nv1
+      # REF: https://github.com/prometheus/node_exporter/issues/3071
+      - --collector.thermal_zone.type-regexp=cpu-thermal|cv[0-9]+-thermal|soc[0-9]+-thermal|tj-thermal
       - --collector.nvme
+      # drm: Intel GPU frequency/engine metrics on mc nodes; nv1 has no DRM card, collector is a no-op there
+      - --collector.drm


### PR DESCRIPTION
## Summary

- Enable `--collector.drm` on node-exporter for Intel GPU frequency/engine metrics on mc1/2/3. nv1 has no DRM card devices (no NVIDIA Talos extension), so the collector is a safe no-op there.
- Replace the blanket `--no-collector.thermal_zone` workaround with a `--collector.thermal_zone.type-regexp` filter. This enables the 8 known-good Orin thermal zones (cpu, cv0/1/2, soc0/1/2, tj) while excluding `gpu-thermal` which returns empty without the NVIDIA Talos extension. On Intel nodes the filter simply matches nothing, so behaviour there is unchanged.

## Node compatibility

| Node | Arch | DRM effect | thermal_zone effect |
|------|------|-----------|---------------------|
| mc1/2/3 | x86_64 | Collects Intel i915 GPU freq/engine data | Filter matches nothing — no change |
| nv1 | arm64 (Jetson Orin) | No DRM card, no-op | Collects cpu/cv/soc/tj temps |

## Test plan

- [ ] ArgoCD syncs prometheus-stack without errors
- [ ] `node_drm_*` metrics appear in Prometheus for mc1/2/3
- [ ] `node_thermal_zone_temp` metrics appear for nv1 (cpu-thermal, cv0/1/2-thermal, soc0/1/2-thermal, tj-thermal)
- [ ] node-exporter pods on nv1 do not hang or crash-loop