### PR TITLE
fix(prometheus): pin node-exporter to master-distroless digest with EINVAL fix

### DIFF
--- a/cluster/apps/system/prometheus-stack/values.yaml
+++ b/cluster/apps/system/prometheus-stack/values.yaml
@@ -180,12 +180,19 @@ kube-prometheus-stack:
           static_configs:
             - targets: ["192.168.50.8:9094"]
   prometheus-node-exporter:
+    # pinned master build 2026-06-23 — includes EINVAL graceful-skip fix (upstream PR #3657)
+    # REF: https://github.com/prometheus/node_exporter/issues/3071
+    # TODO: switch back to quay.io release once v1.11.2+ ships
+    version: "1.11.1"
+    image:
+      registry: ghcr.io
+      repository: prometheus/node-exporter
+      tag: master
+      distroless: true
+      digest: sha256:1f980cd31932379b37aefec13f5883bc3827403ffaebb55c8bec7340d960427c
     extraArgs:
       - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
       - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
-      # thermal_zone: filter to known-good Tegra (Orin) zones; excludes gpu-thermal which returns empty on nv1
-      # REF: https://github.com/prometheus/node_exporter/issues/3071
-      - --collector.thermal_zone.type-regexp=cpu-thermal|cv[0-9]+-thermal|soc[0-9]+-thermal|tj-thermal
       - --collector.nvme
       # drm: Intel GPU frequency/engine metrics on mc nodes; nv1 has no DRM card, collector is a no-op there
       - --collector.drm


### PR DESCRIPTION
## Summary

Fixes a `CrashLoopBackOff` on `mc2` caused by an invalid `--collector.thermal_zone.type-regexp` flag that does not exist in node-exporter v1.11.1 (or any released version). Switches to a pinned `master-distroless` build from ghcr.io that includes the upstream EINVAL graceful-skip fix (PR #3657), which handles the Jetson `gpu-thermal` zone correctly.

## Changes

- **prometheus-stack/values.yaml**: Remove invalid `--collector.thermal_zone.type-regexp` flag (thermal_zone collector enabled by default — no flag needed)
- **prometheus-stack/values.yaml**: Override node-exporter image to `ghcr.io/prometheus/node-exporter:master-distroless@sha256:1f980cd…` (built 2026-06-23, includes [upstream fix for EINVAL on Jetson gpu-thermal](https://github.com/prometheus/node_exporter/pull/3657))
- **prometheus-stack/values.yaml**: Set `version: "1.11.1"` to satisfy the chart's internal `semverCompare` check (which cannot parse `master` as a semver)

## Files Changed

| File | Change |
|---|---|
| `cluster/apps/system/prometheus-stack/values.yaml` | Modified |

## Testing

- Rendered with `helm template` — image resolves to `ghcr.io/prometheus/node-exporter:master-distroless@sha256:1f980cd31932379b37aefec13f5883bc3827403ffaebb55c8bec7340d960427c`, no invalid flags
- `task lint:yaml lint:helm` passes clean
- mc1/mc3/nv1 pods currently healthy; mc2 pod in CrashLoopBackOff will recover once ArgoCD applies the new DaemonSet

## Related Issues

Relates to upstream https://github.com/prometheus/node_exporter/issues/3071 (thermal_zone collector stuck on Jetson)

TODO: revert image override back to `quay.io/prometheus/node-exporter` once v1.11.2+ is released with the EINVAL fix included.