### PR TITLE
fix(cilium): exclude nv1 from L2 announcement elections via nodeSelector

### DIFF
--- a/cluster/apps/core/cilium/templates/config.yaml
+++ b/cluster/apps/core/cilium/templates/config.yaml
@@ -15,6 +15,15 @@ spec:
   loadBalancerIPs: true
   interfaces:
     - ^(eth0|enP8p1s0)$
+  # nv1 (Jetson Tegra ARM64) wins lease elections but its eBPF ARP responder
+  # does not deliver replies to other nodes — kernel/NIC quirk on enP8p1s0.
+  # Restrict L2 announcements to the x86 mc nodes only.
+  nodeSelector:
+    matchExpressions:
+      - key: kubernetes.io/hostname
+        operator: NotIn
+        values:
+          - nv1
 ---
 apiVersion: "cilium.io/v2alpha1"
 kind: CiliumLoadBalancerIPPool


### PR DESCRIPTION
## Summary

nv1 (Jetson Xavier NX, Tegra ARM64, kernel 6.18.29) consistently wins all Cilium L2 announcement lease elections but its eBPF ARP responder does not deliver ARP replies to other nodes — a kernel/NIC quirk on `enP8p1s0`. This causes all LB service IPs (envoy-internal .21, envoy-external .20, jellyfin, game servers, HA audio, Coder SSH workspaces) to become unreachable from the local network whenever nv1 holds the leases.

Root cause: when mc nodes' Cilium pods restarted (they're 9 days old vs nv1's 32 days), nv1 won all 18 lease elections. The eBPF `cilium_l2_respo` map has correct entries and the JIT-compiled TC ingress program runs on `enP8p1s0`, but ARP replies don't reach peers — nv1 itself shows `192.168.48.21 FAILED` in its own ARP table for VIPs it's supposed to announce.

## Changes

- `cluster/apps/core/cilium/templates/config.yaml`: add `nodeSelector` to `CiliumL2AnnouncementPolicy` excluding nv1 by hostname — restricts L2 elections to mc1/mc2/mc3 (x86, standard Talos kernel) which work correctly

## Files Changed

| File | Change |
|------|--------|
| `cluster/apps/core/cilium/templates/config.yaml` | Modified |

## Testing

After merging: delete all leases currently held by nv1 so mc nodes re-acquire them, then verify ARP for 192.168.48.21 resolves on mc1.

## Related Issues

None