### PR TITLE
fix(renovate): handle prometheus node-exporter tag+distroless+digest pattern

### DIFF
--- a/.github/renovate/customManagers.json5
+++ b/.github/renovate/customManagers.json5
@@ -10,6 +10,16 @@
       "registryUrlTemplate": "https://docker.gitea.com",
       "datasourceTemplate": "docker",
       "autoReplaceStringTemplate": "{{indentation}}tag: {{newValue}}\n{{indentation}}digest: {{#if newDigest}}{{{newDigest}}}{{else}}{{{currentDigest}}}{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Apply an explicit prometheus node-exporter digest field match (tag and digest are separated by distroless field)",
+      "fileMatch": ["cluster/apps/system/prometheus-stack/values\\.yaml"],
+      "matchStrings": ["(?<indentation>[ \\t]+)tag: (?<currentValue>[^@\\n]+)\\n[ \\t]+distroless: true\\n[ \\t]+digest: (?<currentDigest>sha256:[a-f0-9]+)"],
+      "depNameTemplate": "prometheus/node-exporter",
+      "registryUrlTemplate": "https://ghcr.io",
+      "datasourceTemplate": "docker",
+      "autoReplaceStringTemplate": "{{indentation}}tag: {{newValue}}\n{{indentation}}distroless: true\n{{indentation}}digest: {{#if newDigest}}{{{newDigest}}}{{else}}{{{currentDigest}}}{{/if}}"
     }
   ]
 }

--- a/.github/renovate/disabledDatasources.json5
+++ b/.github/renovate/disabledDatasources.json5
@@ -14,6 +14,13 @@
       "enabled": false
     },
     {
+      "description": "Disable default manager for prometheus node-exporter (custom regex manager handles tag+distroless+digest fields separately)",
+      "matchManagers": ["helm-values"],
+      "matchPackageNames": ["ghcr.io/prometheus/node-exporter"],
+      "matchFileNames": ["cluster/apps/system/prometheus-stack/values.yaml"],
+      "enabled": false
+    },
+    {
       "description": "Disable pinDigests for talconfig.yaml and Taskfile.yaml (talosVersion/kubernetesVersion format is incompatible with @sha256 suffixes)",
       "matchFileNames": ["provision/talos/talconfig.yaml", ".taskfiles/talos/Taskfile.yaml"],
       "pinDigests": false


### PR DESCRIPTION
## Summary

- Fixes the conflict in PR #4254 where Renovate's `helm-values` manager was appending `@sha256:NEW` to the `tag` field while leaving the chart's separate `digest` field holding the OLD sha256, producing a broken/conflicting image reference on deployment
- Adds a custom regex manager for `prometheus-stack/values.yaml` that updates only the `digest` field (same pattern already in use for Gitea)
- Disables the `helm-values` manager for `ghcr.io/prometheus/node-exporter` in that file so the `tag` field stays clean (`master`, not `master@sha256:...`)

## Test plan

- [ ] Renovate config JSON5 is valid (linted)
- [ ] After merge, trigger a Renovate rebase on PR #4254 — the prometheus-stack diff should change from `tag: master@sha256:...` (bad) to `digest: sha256:NEW` (correct)
- [ ] Confirm the anytype changes in #4254 are unaffected