### PR TITLE
fix(anytype): use mongo 8.0 as intermediate upgrade step before 8.3

### DIFF
--- a/cluster/apps/default/anytype/values.yaml
+++ b/cluster/apps/default/anytype/values.yaml
@@ -2,7 +2,7 @@ anytype:
   mongodb:
     image:
       repository: mongo
-      tag: "8.3@sha256:48a009d2d8007e92d6d7e8baa31713cd11c48c06e827e856240e5a1d319b49d9"
+      tag: "8.0@sha256:45b422ba19c0f028a917ea43746ab8e8cdbdaaeb50d2e6e634a17c59666e0dbb"
   redis:
     image:
       repository: redis/redis-stack-server


### PR DESCRIPTION
## Summary

- MongoDB 8.3 crashed on startup because the data files have `featureCompatibilityVersion: 7.0`
- MongoDB 8.3 only accepts FCV values `8.0`, `8.2`, `8.3` — it cannot upgrade directly from 7.0
- This PR sets the image to `8.0` so MongoDB can migrate the FCV first

## Root cause

```
"Wrong mongod version" — UPGRADE PROBLEM: Invalid featureCompatibilityVersion '7.0'.
Expected one of: '8.3', '8.2', '8.0'.
```

PR #4257 jumped directly from 7.0 → 8.3, skipping the required intermediate 8.0 step.

## Next steps

After this merges and MongoDB 8.0 comes up healthy, Renovate's existing PR (#4257 or a new one) can upgrade to 8.3 safely.

## Test plan

- [ ] Merge this PR and confirm `mongo-1-0` pod reaches `Running` state in the `anytype` namespace
- [ ] Verify anytype coordinator/syncnode/consensusnode reconnect
- [ ] Then re-apply the 8.3 upgrade