### PR TITLE
feat(anytype): upgrade mongo 8.0 → 8.3

### DIFF
--- a/cluster/apps/default/anytype/values.yaml
+++ b/cluster/apps/default/anytype/values.yaml
@@ -2,7 +2,7 @@ anytype:
   mongodb:
     image:
       repository: mongo
-      tag: "8.0@sha256:45b422ba19c0f028a917ea43746ab8e8cdbdaaeb50d2e6e634a17c59666e0dbb"
+      tag: "8.3@sha256:48a009d2d8007e92d6d7e8baa31713cd11c48c06e827e856240e5a1d319b49d9"
   redis:
     image:
       repository: redis/redis-stack-server


### PR DESCRIPTION
## Summary

- MongoDB 8.0 is running and healthy — FCV has been migrated from 7.0 to 8.0
- This completes the upgrade path: 7.0 → 8.0 (via #4269) → 8.3

MongoDB 8.3 accepts FCV `8.0`, so this upgrade is now safe.