### PR TITLE
fix(anytype): revert mongo to 8.0 to set FCV before 8.3

### DIFF
--- a/cluster/apps/default/anytype/values.yaml
+++ b/cluster/apps/default/anytype/values.yaml
@@ -2,7 +2,7 @@ anytype:
   mongodb:
     image:
       repository: mongo
-      tag: "8.3@sha256:48a009d2d8007e92d6d7e8baa31713cd11c48c06e827e856240e5a1d319b49d9"
+      tag: "8.0@sha256:45b422ba19c0f028a917ea43746ab8e8cdbdaaeb50d2e6e634a17c59666e0dbb"
   redis:
     image:
       repository: redis/redis-stack-server


### PR DESCRIPTION
## Summary

- MongoDB 8.0 does **not** auto-upgrade `featureCompatibilityVersion` — it must be set explicitly
- We merged 8.3 before running `setFeatureCompatibilityVersion: "8.0"`, so 8.3 still sees FCV 7.0 and crashes

## Next steps after merging

Once MongoDB 8.0 is running, exec in and set the FCV:

\`\`\`sh
kubectl exec -n anytype mongo-1-0 -- mongosh --port 27001 --eval 'db.adminCommand({setFeatureCompatibilityVersion: "8.0", confirm: true})'
\`\`\`

Then the 8.3 upgrade PR can be re-merged safely.