### PR TITLE
fix(renovate): limit hermes-agent digest auto-merge to weekly schedule

### DIFF
--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -61,6 +61,13 @@
       "separateMinorPatch": true
     },
     {
+      "description": "Hermes agent — weekly digest updates only (frequent main builds cause excessive pod restarts)",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["nousresearch/hermes-agent"],
+      "matchUpdateTypes": ["digest"],
+      "automergeSchedule": ["before 5am on monday"]
+    },
+    {
       "description": "AzerothCore WoW server images",
       "matchDatasources": ["docker"],
       "matchPackageNames": [


### PR DESCRIPTION
## Summary

The `nousresearch/hermes-agent:main` image receives new Docker digest builds multiple times per day (3–5 builds/day). The existing \"Auto cluster apps\" Renovate rule was auto-merging every digest update immediately, causing a pod replacement (and Discord \"⚠️ Gateway shutting down\" message) each time — up to 5 restarts per day.

## Changes

- Added a `packageRule` in `groups.json5` for `nousresearch/hermes-agent` digest updates, setting `automergeSchedule: ["before 5am on monday"]` — same pattern used for AzerothCore images
- Renovate will now batch all week's digest bumps and apply the latest one on Monday mornings instead of instantly

## Files Changed

| File | Change |
|---|---|
| `.github/renovate/groups.json5` | Added hermes-agent weekly digest schedule rule |

## Testing

Renovate will pick up the new rule on its next run. No cluster changes required.

## Related Issues

Debugged via Discord "Gateway shutting down" messages appearing every 2–5 hours.