### PR TITLE
chore(coder,ollama): reduce over-provisioned PVC sizes

### DIFF
--- a/cluster/apps/ai/coder/values.yaml
+++ b/cluster/apps/ai/coder/values.yaml
@@ -47,7 +47,7 @@ pgsql-cnpg:
   imageName: ghcr.io/cloudnative-pg/postgresql:17.6-standard-bookworm
   instances: 2
   storage:
-    size: 10Gi
+    size: 5Gi
   resources:
     requests:
       memory: 256Mi

--- a/cluster/apps/ai/coder/workspace-template/main.tf
+++ b/cluster/apps/ai/coder/workspace-template/main.tf
@@ -47,7 +47,7 @@ data "coder_parameter" "storage_size" {
   display_name = "Storage Size"
   description = "Home directory PVC size"
   type        = "string"
-  default     = "20Gi"
+  default     = "2Gi"
   mutable     = false
   order       = 4
 }

--- a/cluster/apps/ai/ollama/values.yaml
+++ b/cluster/apps/ai/ollama/values.yaml
@@ -25,7 +25,7 @@ ollama:
     enabled: false
   persistentVolume:
     enabled: true
-    size: "100Gi"
+    size: "40Gi"
   resources:
     limits:
       gpu.intel.com/i915: 1


### PR DESCRIPTION
## Summary
- Coder workspace home PVCs (`coder-mmalyska-*-home`) template default reduced 20Gi → 2Gi — existing workspaces were sitting empty (only default dotfiles, no project data)
- `coderdb-cnpg` Postgres storage 10Gi → 5Gi — actual usage was ~717Mi (8%)
- `ollama` PVC 100Gi → 40Gi — actual usage was 32Gi of pulled models

## Notes
- Coder workspace home size change only applies to newly-created workspaces (`mutable = false` on the coder_parameter); existing 5 workspace PVCs are left as-is per user decision, not resized.
- Once merged, `coderdb-cnpg` will need a manual delete/resync/switchover of each replica's PVC (K8s can't shrink PVCs in place) — planned as a follow-up live operation.
- `ollama` PVC will be deleted and recreated at 40Gi; models will re-pull automatically from the `models.pull` list in values.yaml.

## Test plan
- [x] `helm template` rendered successfully for both charts with new sizes reflected
- [ ] After merge: verify ArgoCD syncs `coderdb-cnpg` and `ollama` Applications
- [ ] Perform live PVC resize operations (replica resync for coderdb, delete+recreate for ollama)