### PR TITLE
revert(coder): keep coderdb-cnpg storage at 10Gi

### DIFF
--- a/cluster/apps/ai/coder/values.yaml
+++ b/cluster/apps/ai/coder/values.yaml
@@ -47,7 +47,7 @@ pgsql-cnpg:
   imageName: ghcr.io/cloudnative-pg/postgresql:17.6-standard-bookworm
   instances: 2
   storage:
-    size: 5Gi
+    size: 10Gi
   resources:
     requests:
       memory: 256Mi


### PR DESCRIPTION
## Summary
- Follow-up to #4369: reverts the coderdb-cnpg storage size back to 10Gi
- CNPG's admission webhook rejects any `Cluster.spec.storage` decrease outright (confirmed via failed ArgoCD sync) — shrinking would require a full new-cluster-from-backup migration with a connection-string cutover, not worth it for ~10Gi of savings when Ceph has 1.1TB free

## Test plan
- [x] Diff limited to the single storage.size revert
- [ ] After merge, sync `coder` ArgoCD app and confirm it goes Healthy (currently in Error state from the failed shrink attempt)