### PR TITLE
fix(nextcloud): correct NFS protocol version and OnlyOffice OOM

### DIFF
--- a/charts/onlyoffice-documentserver/templates/deployment.yaml
+++ b/charts/onlyoffice-documentserver/templates/deployment.yaml
@@ -30,6 +30,24 @@ spec:
                   key: {{ .Values.jwt.secretKey }}
             - name: JWT_HEADER
               value: "Authorization"
+            - name: DB_TYPE
+              value: "postgres"
+            - name: DB_HOST
+              value: {{ .Values.database.host | quote }}
+            - name: DB_PORT
+              value: {{ .Values.database.port | quote }}
+            - name: DB_NAME
+              value: {{ .Values.database.name | quote }}
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret.name }}
+                  key: {{ .Values.database.existingSecret.usernameKey }}
+            - name: DB_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret.name }}
+                  key: {{ .Values.database.existingSecret.passwordKey }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           readinessProbe:

--- a/charts/onlyoffice-documentserver/values.yaml
+++ b/charts/onlyoffice-documentserver/values.yaml
@@ -12,7 +12,7 @@ storage:
 resources:
   requests:
     cpu: 250m
-    memory: 512Mi
-  limits:
-    cpu: "1"
     memory: 1Gi
+  limits:
+    cpu: "2"
+    memory: 3Gi

--- a/charts/onlyoffice-documentserver/values.yaml
+++ b/charts/onlyoffice-documentserver/values.yaml
@@ -6,6 +6,14 @@ port: 80
 jwt:
   secretName: onlyoffice-jwt-secret
   secretKey: JWT_SECRET
+database:
+  host: onlyofficedb-cnpg-rw
+  port: 5432
+  name: app
+  existingSecret:
+    name: onlyofficedb-cnpg-app
+    usernameKey: username
+    passwordKey: password
 storage:
   storageClass: ceph-block
   size: 5Gi

--- a/cluster/apps/default/nextcloud/app/templates/nfs-data-pv.yaml
+++ b/cluster/apps/default/nextcloud/app/templates/nfs-data-pv.yaml
@@ -17,7 +17,7 @@ spec:
     server: qnap.<secret:private-domain>
     path: "/nextcloud-data"
   mountOptions:
-    - nfsvers=4.2
+    - nfsvers=4.1
     - tcp
     - intr
     - hard

--- a/cluster/apps/default/nextcloud/onlyoffice/Chart.yaml
+++ b/cluster/apps/default/nextcloud/onlyoffice/Chart.yaml
@@ -7,3 +7,6 @@ dependencies:
   - name: onlyoffice-documentserver
     version: 1.0.0
     repository: file://../../../../../charts/onlyoffice-documentserver/
+  - name: pgsql-cnpg
+    version: 1.3.2
+    repository: file://../../../../../charts/pgsql-cnpg/

--- a/cluster/apps/default/nextcloud/onlyoffice/templates/s3-externalsecret.yaml
+++ b/cluster/apps/default/nextcloud/onlyoffice/templates/s3-externalsecret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: onlyoffice-s3-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  refreshInterval: 1h
+  target:
+    name: onlyoffice-s3-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: S3_ACCESS_KEY_ID
+      remoteRef:
+        key: "e00e1e38-ae37-479a-8b46-b409016331eb" #gitleaks:allow #S3_ACCESS_KEY
+    - secretKey: S3_ACCESS_SECRET_KEY
+      remoteRef:
+        key: "4d5a418c-82ed-4b8e-bfbf-b40901634ea4" #gitleaks:allow #S3_SECRET_KEY

--- a/cluster/apps/default/nextcloud/onlyoffice/values.yaml
+++ b/cluster/apps/default/nextcloud/onlyoffice/values.yaml
@@ -1,2 +1,41 @@
 onlyoffice-documentserver:
   namespace: nextcloud
+
+pgsql-cnpg:
+  name: onlyofficedb
+  imageName: ghcr.io/cloudnative-pg/postgresql:15.10-standard-bookworm
+  instances: 2
+  storage:
+    size: 5Gi
+  resources:
+    requests:
+      memory: 200Mi
+      cpu: 100m
+    limits:
+      memory: 512Mi
+      cpu: 500m
+  monitoring:
+    enablePodMonitor: true
+  retentionPolicy: "10d"
+  objectStore:
+    destinationPath: "s3://k8s-at-home-backup/cnpg/onlyoffice"
+    endpointURL: <secret:s3_endpoint>
+    s3Credentials:
+      accessKeyId:
+        name: onlyoffice-s3-secret
+        key: S3_ACCESS_KEY_ID
+      secretAccessKey:
+        name: onlyoffice-s3-secret
+        key: S3_ACCESS_SECRET_KEY
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
+      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+        value: when_required
+  scheduledBackups:
+    - name: onlyofficedb-cnpg-backup
+      spec:
+        immediate: true
+        schedule: "25 0 0 * * *"
+        backupOwnerReference: self

--- a/docs/superpowers/plans/2026-07-02-nextcloud-onedrive-replacement.md
+++ b/docs/superpowers/plans/2026-07-02-nextcloud-onedrive-replacement.md
@@ -343,6 +343,8 @@ resources:
     memory: 1Gi
 ```
 
+**Update from Task 8 (post-deploy):** the 1Gi memory limit was too low — the OnlyOffice container was OOMKilled repeatedly during startup (exit 137). Document Server runs ~10 internal processes (docservice, converter, spellchecker, its own nginx/redis/rabbitmq, etc.) and needs more headroom than initially estimated. Bumped to `requests: {cpu: 250m, memory: 1Gi}` / `limits: {cpu: "2", memory: 3Gi}` in `charts/onlyoffice-documentserver/values.yaml` — cluster nodes had ample free memory to absorb this.
+
 - [ ] **Step 3: Write the Deployment template**
 
 Create `charts/onlyoffice-documentserver/templates/deployment.yaml`:


### PR DESCRIPTION
## Summary
Post-deploy fixes found after merging #4387 and running ArgoCD sync:
- `nextcloud-data-pv` failed to mount: `mount.nfs: Protocol not supported`. The QNAP TS-251D doesn't support NFSv4.2 (only 4.1) — confirmed by every other working NFS PV in the cluster (jellyfin, bookorbit) already using 4.1.
- OnlyOffice Document Server was OOMKilled repeatedly at the original 1Gi memory limit. Bumped to 1Gi request / 3Gi limit.
- OnlyOffice's embedded PostgreSQL externalized to a dedicated `pgsql-cnpg` cluster (`onlyofficedb-cnpg`), matching every other app's DB pattern in this repo, with S3 backup via the shared CNPG backup credential. RabbitMQ stays embedded (no existing broker in the cluster, not a meaningful memory contributor).

## Test plan
- [x] `helm template` renders both charts clean with the new values
- [ ] ArgoCD sync picks up all three fixes (selfHeal enabled)
- [ ] `nextcloud-data-pvc` binds successfully
- [ ] OnlyOffice pod reaches Running/Ready without OOMKill
- [ ] `onlyofficedb-cnpg` cluster comes up healthy and OnlyOffice connects to it (not its embedded DB)