### PR TITLE
fix(nextcloud): add missing external-dns annotation to HTTPRoute

### DIFF
--- a/cluster/apps/default/nextcloud/app/values.yaml
+++ b/cluster/apps/default/nextcloud/app/values.yaml
@@ -114,6 +114,8 @@ nextcloud:
     type: sidecar
   httpRoute:
     enabled: true
+    annotations:
+      external-dns.alpha.kubernetes.io/controller: dns-controller
     hostnames:
       - nextcloud.<secret:private-domain>
     parentRefs:


### PR DESCRIPTION
## Summary
`nextcloud.mmalyska.cloud` never got a DNS record. Root cause: the official Nextcloud chart's native `httpRoute` values block doesn't set `external-dns.alpha.kubernetes.io/controller: dns-controller` by default (unlike our own hand-written HTTPRoute templates, which always include it per the add-app skill convention). Without it, `cloudflare-dns`'s `--annotation-filter` silently excludes the route — no error logged, it just never considered it a DNS source. Restarting the controller (already tried) didn't help because there was nothing wrong with its cache; it correctly had nothing to do given the filter.

Confirmed via comparison with `hass-proxy`'s HTTPRoute, which has the annotation and resolves fine.

## Test plan
- [x] `helm template` renders the annotation onto the HTTPRoute
- [ ] After sync, `cloudflare-dns` creates the record and `nextcloud.mmalyska.cloud` resolves