### PR TITLE
fix(nextcloud): disable Rocket Loader

### DIFF
--- a/.claude/skills/dev-workflow/SKILL.md
+++ b/.claude/skills/dev-workflow/SKILL.md
@@ -32,7 +32,7 @@ task argocd:sync                      # Sync ArgoCD applications
 
 # Terraform
 task terraform:plan:cloudflare
-task terraform:apply:cloudflare
+task terraform:apply:cloudflare          # Local/manual only -- see note below
 
 # Lint / Format
 task lint:all
@@ -49,6 +49,18 @@ Uses a devcontainer (`ghcr.io/mmalyska/home-ops-devcontainer:main`). On containe
 3. Task subtasks are initialized
 
 Required secrets for devcontainer: `TERRAFORM_TOKEN`
+
+### HCP Terraform (Cloudflare workspace)
+
+The `provision/terraform/cloudflare` workspace is VCS-connected to this repo in HCP Terraform (app.terraform.io) with **auto-apply enabled** — merging a PR that touches `provision/terraform/cloudflare/**` to `main` triggers the apply automatically. `task terraform:apply:cloudflare` is only needed for local/manual runs (e.g. testing before opening a PR); don't run it after merging, HCP Terraform already handles it.
+
+To run `task terraform:plan:cloudflare` (or any local terraform command) against this workspace, the CLI needs a token even though `TERRAFORM_TOKEN` is already set as an env var — export it under the name Terraform's credential lookup expects:
+```sh
+export TF_TOKEN_app_terraform_io="$TERRAFORM_TOKEN"
+```
+Without this, `terraform init` fails with "Required token could not be found."
+
+**Gotcha:** `.terraform.lock.hcl` is gitignored (local-only) and its init state is per-directory — each git worktree has its own, independent of the main checkout. If `main.tf`'s provider version constraint was bumped (e.g. by a Renovate PR) since you last ran `terraform init` *in that specific working directory*, you'll get "locked provider ... does not match configured version constraint" on both local and remote (CLI-driven) runs. Fix: `TF_TOKEN_app_terraform_io="$TERRAFORM_TOKEN" terraform init -upgrade` from `provision/terraform/cloudflare/` in the worktree you're actually working in.
 
 ## CI/CD
 

--- a/provision/terraform/cloudflare/zone.tf
+++ b/provision/terraform/cloudflare/zone.tf
@@ -77,6 +77,32 @@ resource "cloudflare_zone_setting" "zone_setting_rocket_loader" {
   value = "on"
 }
 
+# Rocket Loader rewrites <script> tags in a way that only its own loader
+# script can execute -- but that loader script isn't nonce'd, so it's
+# blocked outright by CSPs using 'strict-dynamic' (e.g. Nextcloud's login
+# page), which silently breaks all JS on the page. Disable it per-host
+# for apps that ship a strict-dynamic CSP, instead of weakening their CSP
+# or disabling Rocket Loader zone-wide.
+resource "cloudflare_ruleset" "zone_level_config_rules" {
+  zone_id     = cloudflare_zone.domain.id
+  name        = "Configuration Rules"
+  description = "Per-host overrides of zone-level settings"
+  kind        = "zone"
+  phase       = "http_config_settings"
+
+  rules = [
+    {
+      action = "set_config"
+      action_parameters = {
+        rocket_loader = false
+      }
+      expression  = "(http.host eq \"nextcloud.${local.cloudflare_domain}\")"
+      description = "Disable Rocket Loader for Nextcloud (breaks strict-dynamic CSP login page)"
+      enabled     = true
+    }
+  ]
+}
+
 resource "cloudflare_zone_setting" "zone_setting_always_online" {
   zone_id = cloudflare_zone.domain.id
   setting_id = "always_online"


### PR DESCRIPTION
## Summary
Nextcloud's `/login` page rendered blank -- no login form, no Keycloak button, nothing. Root cause, confirmed by fetching the real page through Cloudflare:

- Cloudflare Rocket Loader (zone-wide setting, `on`) rewrites `<script>` tags so only its own injected loader script can execute them.
- That loader script isn't nonce'd, so it's blocked outright by Nextcloud's CSP (`script-src-elem 'strict-dynamic' 'nonce-...'`).
- Rocket Loader had already rewritten `core-login.js` (the script that renders Nextcloud's client-side login form) into a non-executable `<script type="...-text/javascript">` tag before the browser ever sees it -- and since the only thing that knows how to run that rewritten tag (Rocket Loader itself) is blocked, the form never renders.

Cloudflare's documented CSP fix (`script-src 'self' ajax.cloudflare.com;`) doesn't work here: per CSP Level 3, `'strict-dynamic'` makes all hostname-based allowlist entries in the same directive ineffective. The only fix that doesn't weaken Nextcloud's CSP is disabling Rocket Loader for this host specifically, via a Configuration Rule (not a zone-wide toggle, since Rocket Loader may still be useful for other apps in this zone).

## Test plan
- [x] `terraform validate` passes
- [x] `terraform plan` shows exactly `1 to add, 0 to change, 0 to destroy` (the new `cloudflare_ruleset.zone_level_config_rules`)