### PR TITLE
fix(nextcloud): fix database wiring so CNPG Postgres is actually used

### DIFF
--- a/cluster/apps/default/nextcloud/app/values.yaml
+++ b/cluster/apps/default/nextcloud/app/values.yaml
@@ -69,6 +69,8 @@ nextcloud:
   phpClientHttpsFix:
     enabled: true
     protocol: https
+  internalDatabase:
+    enabled: false
   externalDatabase:
     enabled: true
     type: postgresql


### PR DESCRIPTION
## Summary
Nextcloud installed itself on SQLite instead of the CNPG Postgres cluster set up earlier in this project. Root cause: the official chart picks its database backend via an if/elseif chain in `templates/_helpers.tpl` -- `internalDatabase.enabled` (SQLite) is checked *before* `externalDatabase`. It defaults to `true` and was never explicitly disabled in our values, so the container always received `SQLITE_DATABASE` and auto-installed against it regardless of the `externalDatabase` block.

Confirmed via `helm template`: before this fix, only `SQLITE_DATABASE` rendered in the container env; after, `SQLITE_DATABASE` is gone and `POSTGRES_HOST`/`POSTGRES_DB`/`POSTGRES_USER`/`POSTGRES_PASSWORD` render correctly against `nextclouddb-cnpg-rw`.

**Important:** this only fixes new installs. The live instance already ran `occ maintenance:install` against SQLite -- fixing the values alone won't migrate existing data. Since this is a fresh instance with no real family data yet, the plan is to delete the small Ceph-backed app-state PVC after this merges/syncs, forcing a clean reinstall against Postgres. Will coordinate that step separately since it's a destructive action on live cluster state.

## Test plan
- [x] `helm template` confirms `SQLITE_DATABASE` no longer renders and `POSTGRES_*` env vars render correctly
- [ ] After merge/sync + PVC wipe, `occ status` / `occ config:system:get dbtype` reports `pgsql`, and admin login works against the fresh install