### PR TITLE
fix(nextcloud): raise OnlyOffice memory limit to 4Gi (still OOMing at 3Gi)

### DIFF
--- a/charts/onlyoffice-documentserver/values.yaml
+++ b/charts/onlyoffice-documentserver/values.yaml
@@ -19,8 +19,8 @@ storage:
   size: 5Gi
 resources:
   requests:
-    cpu: 250m
-    memory: 1Gi
+    cpu: 500m
+    memory: 2Gi
   limits:
     cpu: "2"
-    memory: 3Gi
+    memory: 4Gi


### PR DESCRIPTION
## Summary
The earlier 1Gi->3Gi memory bump (#4402) wasn't enough -- the OnlyOffice pod OOMKilled again after ~14 minutes of uptime, RSS climbing past 1.7Gi with the limit at 3Gi. Bumped to 2Gi request / 4Gi limit. Cluster nodes have plenty of headroom (32-50% memory used across all 4 nodes).

## Test plan
- [x] `helm template` renders the new limits correctly
- [ ] After sync, OnlyOffice pod stays up without OOMKilling under normal idle + light editing load