### PR TITLE
fix(nextcloud): bump onlyoffice-documentserver chart version to bust ArgoCD's stale dependency cache

### DIFF
--- a/charts/onlyoffice-documentserver/Chart.yaml
+++ b/charts/onlyoffice-documentserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: onlyoffice-documentserver
 description: OnlyOffice Document Server (Community Edition)
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "9.0.0"

--- a/cluster/apps/default/nextcloud/onlyoffice/Chart.yaml
+++ b/cluster/apps/default/nextcloud/onlyoffice/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 appVersion: "9.0.0"
 dependencies:
   - name: onlyoffice-documentserver
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../../../../../charts/onlyoffice-documentserver/
   - name: pgsql-cnpg
     version: 1.3.2


### PR DESCRIPTION
## Summary
After merging #4413 (memory limit 3Gi -> 4Gi), ArgoCD reported the app Synced/Healthy, but the live Deployment still had the *old* resource values from #4402 (1Gi request / 3Gi limit) -- not the new ones. Root cause: ArgoCD's repo-server caches `file://` Helm chart dependencies by `name@version`. `charts/onlyoffice-documentserver`'s `version: 1.0.0` never changed across either memory-limit edit, so the CMP's `helm dependency update` step kept reusing a stale packaged `.tgz` instead of re-reading the current directory content -- silently serving old values even though git and ArgoCD's own diff both looked correct.

Fix: bump `charts/onlyoffice-documentserver/Chart.yaml` to `1.0.1` and the corresponding dependency pin in `cluster/apps/default/nextcloud/onlyoffice/Chart.yaml`, forcing a fresh fetch.

**Going forward**: any future change to `charts/onlyoffice-documentserver` (or any other local `file://` chart in this repo) needs a version bump in `Chart.yaml` to actually take effect through ArgoCD -- editing `values.yaml`/templates alone isn't enough.

## Test plan
- [x] `helm template` confirms 4Gi limit renders correctly with the version bump
- [ ] After sync, live Deployment resources actually show 2Gi request / 4Gi limit