### PR TITLE
fix(nextcloud): disable OnlyOffice plugin manager (real cause of repeated OOMKills)

### DIFF
--- a/charts/onlyoffice-documentserver/Chart.yaml
+++ b/charts/onlyoffice-documentserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: onlyoffice-documentserver
 description: OnlyOffice Document Server (Community Edition)
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "9.0.0"

--- a/charts/onlyoffice-documentserver/templates/deployment.yaml
+++ b/charts/onlyoffice-documentserver/templates/deployment.yaml
@@ -30,6 +30,8 @@ spec:
                   key: {{ .Values.jwt.secretKey }}
             - name: JWT_HEADER
               value: "Authorization"
+            - name: PLUGINS_ENABLED
+              value: "false"
             - name: DB_TYPE
               value: "postgres"
             - name: DB_HOST

--- a/cluster/apps/default/nextcloud/onlyoffice/Chart.yaml
+++ b/cluster/apps/default/nextcloud/onlyoffice/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 appVersion: "9.0.0"
 dependencies:
   - name: onlyoffice-documentserver
-    version: 1.0.1
+    version: 1.0.2
     repository: file://../../../../../charts/onlyoffice-documentserver/
   - name: pgsql-cnpg
     version: 1.3.2


### PR DESCRIPTION
## Summary
The repeated OnlyOffice OOMKills weren't actually about the memory limit being too low (raised twice already: 1Gi->3Gi in #4402, 3Gi->4Gi in #4413) -- confirmed via \`ps aux\` inside the running pod that \`documentserver-pluginsmanager\` (triggered by \`PLUGINS_ENABLED\` defaulting to \`true\`) was pegged at ~95% CPU, using 1.3Gi+ RSS and climbing, for 7+ minutes with no sign of finishing. The container's own \`run-document-server.sh\` starts this as a background process (\`start_process documentserver-pluginsmanager.sh ... --update=".../plugin-list-default.json"\`) trying to install/update the default plugin list, and it never completes -- eventually exhausting whatever memory limit is set, regardless of how high.

Fix: \`PLUGINS_ENABLED=false\` skips this step entirely. Not needed for basic document viewing/editing (no third-party plugins in use). Also bumped the local chart's version (per the stale-cache gotcha found in #4414) so this actually takes effect through ArgoCD.

## Test plan
- [x] \`helm template\` confirms \`PLUGINS_ENABLED=false\` renders
- [ ] After sync, OnlyOffice pod stays up without OOMKilling, and \`ps aux\` no longer shows a runaway \`pluginsmanager\` process
- [ ] Document editing still works without third-party plugins