### PR TITLE
fix(nextcloud): fix Volsync backup permission error on config.php

### DIFF
--- a/cluster/apps/default/nextcloud/app/templates/volsync.yaml
+++ b/cluster/apps/default/nextcloud/app/templates/volsync.yaml
@@ -14,3 +14,5 @@ spec:
       daily: 6
       weekly: 4
       monthly: 2
+    moverSecurityContext:
+      fsGroup: 82


### PR DESCRIPTION
## Summary
Volsync backup runs completed but silently skipped \`config.php\`: \`error: /data/config/config.php: open config/config.php: permission denied\`. The restic mover pod had no group membership matching \`config.php\`'s owner (\`www-data:www-data\`, mode 660, gid 82), so it couldn't read it despite the backup otherwise succeeding.

Fix: \`moverSecurityContext.fsGroup: 82\` matches the value already used by the Nextcloud pod's own \`securityContext.fsGroup\` (confirmed via \`kubectl get deployment nextcloud-app -o jsonpath='{.spec.template.spec.securityContext}'\` -> \`{"fsGroup":82}\`).

## Test plan
- [x] \`helm template\` confirms \`moverSecurityContext.fsGroup: 82\` renders on the ReplicationSource
- [ ] Next scheduled backup (or a manual trigger) completes with no permission-denied warnings