### PR TITLE
feat(nextcloud): expose OnlyOffice publicly (office.<domain>) for browser editor loading

### DIFF
--- a/cluster/apps/default/nextcloud/onlyoffice/templates/httproute.yaml
+++ b/cluster/apps/default/nextcloud/onlyoffice/templates/httproute.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: onlyoffice
+  annotations:
+    external-dns.alpha.kubernetes.io/controller: dns-controller
+spec:
+  parentRefs:
+    - name: envoy-external
+      namespace: envoy-gateway
+      sectionName: https
+  hostnames:
+    - office.<secret:private-domain>
+  rules:
+    - backendRefs:
+        - name: onlyoffice
+          port: 80


### PR DESCRIPTION
## Summary
Document editing failed with \"There is no plugin available to display this file type\" in Nextcloud. Root cause: the ONLYOFFICE connector needs two distinct URLs -- \`DocumentServerInternalUrl\` (server-side, PHP -> Document Server, already configured in Task 9) and \`DocumentServerUrl\` (the public URL the user's **browser** loads the editor JS/UI from directly). Only the internal one was ever set. Since Document Server was deployed ClusterIP-only ("not internet-facing" was the original design decision), there was no public URL for the browser to load the editor from at all.

This PR adds a public HTTPRoute for OnlyOffice at \`office.<private-domain>\` on the same \`envoy-external\` gateway/Cloudflare tunnel as other public apps, with the `dns-controller` annotation included this time (previous gotcha from #4403). Exposing it is safe: \`JWT_ENABLED=true\` already requires a signed token for any document operation.

**Follow-up needed after merge**: run \`occ config:app:set onlyoffice DocumentServerUrl --value="https://office.<private-domain>/"\` once the route is live and DNS resolves.

## Test plan
- [x] \`helm template\` renders the HTTPRoute with the external-dns annotation
- [ ] After sync, \`office.<private-domain>\` resolves and is reachable
- [ ] After setting \`DocumentServerUrl\`, opening a .docx in Nextcloud loads the OnlyOffice editor instead of erroring