### PR TITLE
fix(nextcloud): try 6Gi memory limit for OnlyOffice before disabling plugins

### DIFF
--- a/charts/onlyoffice-documentserver/Chart.yaml
+++ b/charts/onlyoffice-documentserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: onlyoffice-documentserver
 description: OnlyOffice Document Server (Community Edition)
 type: application
-version: 1.0.1
+version: 1.0.3
 appVersion: "9.0.0"

--- a/charts/onlyoffice-documentserver/values.yaml
+++ b/charts/onlyoffice-documentserver/values.yaml
@@ -20,7 +20,7 @@ storage:
 resources:
   requests:
     cpu: 500m
-    memory: 2Gi
+    memory: 3Gi
   limits:
     cpu: "2"
-    memory: 4Gi
+    memory: 6Gi

--- a/cluster/apps/default/nextcloud/onlyoffice/Chart.yaml
+++ b/cluster/apps/default/nextcloud/onlyoffice/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 appVersion: "9.0.0"
 dependencies:
   - name: onlyoffice-documentserver
-    version: 1.0.1
+    version: 1.0.3
     repository: file://../../../../../charts/onlyoffice-documentserver/
   - name: pgsql-cnpg
     version: 1.3.2


### PR DESCRIPTION
## Summary
Alternative to #4417. Instead of disabling the plugin manager (which loses draw.io, code highlighting, macros, photo editor, speech-to-text, thesaurus, translator, YouTube embed, Zotero/Mendeley), try giving it more headroom first: 3Gi request / 6Gi limit (up from 2Gi/4Gi). Cluster nodes have plenty of free memory (36-49% used across all 4 nodes) to test this safely.

If the pod still OOMs at 6Gi, that's a strong signal the plugin manager hang is a genuine bug/infinite loop rather than just slow legitimate work, and #4417 (disable plugins) becomes the right call instead.

## Test plan
- [x] \`helm template\` confirms 6Gi limit renders
- [ ] After sync, monitor whether the OnlyOffice pod stabilizes without OOMKilling, and whether \`pluginsmanager\` in \`ps aux\` actually completes (prints "Done" / process exits) rather than running indefinitely