### PR TITLE
fix(nextcloud): disable OnlyOffice plugin manager (confirmed runaway via 40min monitoring), revert memory to 1Gi/2Gi

### DIFF
--- a/charts/onlyoffice-documentserver/Chart.yaml
+++ b/charts/onlyoffice-documentserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: onlyoffice-documentserver
 description: OnlyOffice Document Server (Community Edition)
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "9.0.0"

--- a/charts/onlyoffice-documentserver/templates/deployment.yaml
+++ b/charts/onlyoffice-documentserver/templates/deployment.yaml
@@ -30,6 +30,8 @@ spec:
                   key: {{ .Values.jwt.secretKey }}
             - name: JWT_HEADER
               value: "Authorization"
+            - name: PLUGINS_ENABLED
+              value: "false"
             - name: DB_TYPE
               value: "postgres"
             - name: DB_HOST

--- a/charts/onlyoffice-documentserver/values.yaml
+++ b/charts/onlyoffice-documentserver/values.yaml
@@ -19,8 +19,8 @@ storage:
   size: 5Gi
 resources:
   requests:
-    cpu: 500m
-    memory: 3Gi
+    cpu: 250m
+    memory: 1Gi
   limits:
-    cpu: "2"
-    memory: 6Gi
+    cpu: "1"
+    memory: 2Gi

--- a/cluster/apps/default/nextcloud/onlyoffice/Chart.yaml
+++ b/cluster/apps/default/nextcloud/onlyoffice/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 appVersion: "9.0.0"
 dependencies:
   - name: onlyoffice-documentserver
-    version: 1.0.3
+    version: 1.0.4
     repository: file://../../../../../charts/onlyoffice-documentserver/
   - name: pgsql-cnpg
     version: 1.3.2


### PR DESCRIPTION
## Summary
Supersedes/closes out the memory-bump experiment from #4420. Monitored the OnlyOffice pod for 40 minutes at the bumped 3Gi/6Gi limit: \`documentserver-pluginsmanager\` grew memory linearly and unboundedly the entire time (1033Mi -> 5790Mi, ~120Mi/min, zero sign of completing, right at the edge of the 6Gi ceiling when monitoring stopped). This confirms it's a genuine runaway/leaking process, not slow legitimate work that just needed more headroom -- raising the limit further would only delay the inevitable OOM.

Fix: \`PLUGINS_ENABLED=false\` skips the plugin manager entirely. Not needed for basic document viewing/editing (no third-party plugins in use) -- loses draw.io, code highlighting, macros, photo editor, speech-to-text, thesaurus, translator, YouTube embed, Zotero/Mendeley, none of which are required for the core family use case.

With the leak eliminated, reverted resources from 3Gi/6Gi back down to 1Gi request / 2Gi limit -- matching ONLYOFFICE's documented minimum for Document Server.

## Test plan
- [x] \`helm template\` confirms \`PLUGINS_ENABLED=false\` and the 1Gi/2Gi resources render correctly
- [ ] After sync, OnlyOffice pod stays stable (no OOMKilling) with \`ps aux\` showing no runaway \`pluginsmanager\` process
- [ ] Document editing (open/edit a .docx) still works without third-party plugins