### PR TITLE
fix(nextcloud): allow local/LAN remote servers for OIDC discovery

### DIFF
--- a/cluster/apps/default/nextcloud/app/values.yaml
+++ b/cluster/apps/default/nextcloud/app/values.yaml
@@ -65,6 +65,11 @@ nextcloud:
             0 => '127.0.0.1',
             1 => '10.244.0.0/16',
           ),
+          // The Keycloak OIDC provider hostname resolves to an in-cluster/LAN
+          // IP, which Nextcloud's SSRF protection blocks by default
+          // (LocalServerException: "violates local access rules") when the
+          // user_oidc app fetches the OIDC discovery document server-side.
+          'allow_local_remote_servers' => true,
         ); ?>
   phpClientHttpsFix:
     enabled: true


### PR DESCRIPTION
## Summary
- Nextcloud's `user_oidc` app fetches the Keycloak OIDC discovery document server-side. Nextcloud's built-in SSRF protection was rejecting this fetch (`OCP\Http\Client\LocalServerException: ... violates local access rules`) because the Keycloak hostname resolves to an in-cluster/LAN IP, not a public one.
- Result: users saw "Could not reach the OpenID Connect provider." on every SSO login attempt.
- Fix: set `allow_local_remote_servers => true` in the `proxy.config.php` override in `cluster/apps/default/nextcloud/app/values.yaml`.

## Test plan
- [x] `helm template` verified the config renders correctly with the new setting
- [ ] After merge + ArgoCD sync, confirm Keycloak login succeeds end-to-end