### PR TITLE
fix(nextcloud): increase PHP-FPM pool size to stop nginx crash-looping

### DIFF
--- a/cluster/apps/default/nextcloud/app/values.yaml
+++ b/cluster/apps/default/nextcloud/app/values.yaml
@@ -71,6 +71,20 @@ nextcloud:
           // user_oidc app fetches the OIDC discovery document server-side.
           'allow_local_remote_servers' => true,
         ); ?>
+    # Default pm.max_children (5) is too small for real browsing load (Files
+    # app fires many parallel requests per page: previews, notifications,
+    # activity). Under load the pool saturates, the nginx sidecar's own
+    # /status.php liveness probe queues behind it, times out, and kubelet
+    # kills nginx -- surfacing to users as "upstream connect error ... remote
+    # connection failure" after a few minutes of normal use.
+    phpConfigs:
+      zz-pool-size.conf: |-
+        [www]
+        pm = dynamic
+        pm.max_children = 20
+        pm.start_servers = 4
+        pm.min_spare_servers = 2
+        pm.max_spare_servers = 8
   phpClientHttpsFix:
     enabled: true
     protocol: https


### PR DESCRIPTION
## Summary
- Users reported the site going down with "upstream connect error or disconnect/reset before headers ... remote connection failure" after normal browsing (not immediately after login/deploy).
- Root cause: the official chart defaults to `pm.max_children = 5` for the PHP-FPM pool. Neither the `nextcloud` nor `nextcloud-nginx` containers have resource limits set, so this isn't a memory/cgroup issue -- it's the pool itself being too small for the concurrent request volume a real Files-app session generates (previews, notifications, activity feed, etc).
- Under load, all 5 workers get busy, new requests -- including the nginx sidecar's own `/status.php` liveness/readiness probe, which it proxies to PHP-FPM -- queue and time out ("context deadline exceeded"). After 3 consecutive probe failures, kubelet kills the nginx container, which the client sees as the Envoy "remote connection failure" error while nginx is down.
- Fix: override `pm.max_children`/`pm.start_servers`/`pm.min_spare_servers`/`pm.max_spare_servers` via the chart's `nextcloud.phpConfigs` hook (mounts to `/usr/local/etc/php-fpm.d/`).

## Test plan
- [x] `helm template` verified the new ConfigMap renders and mounts at `/usr/local/etc/php-fpm.d/zz-pool-size.conf` on both the `nextcloud` and `nextcloud-cron` containers
- [ ] After merge + ArgoCD sync, confirm nginx no longer crash-loops under normal multi-tab browsing