### PR TITLE
feat: cut over Home Assistant MQTT to RabbitMQ

### DIFF
--- a/cluster/apps/home-automation/home-assistant/templates/secrets.yaml
+++ b/cluster/apps/home-automation/home-assistant/templates/secrets.yaml
@@ -17,7 +17,7 @@ spec:
         SECRET_EXTERNAL_URL: "https://dom.<secret:private-domain>"
         SECRET_MQTT_USERNAME: "{{ `{{ .HOME_ASSISTANT_USERNAME }}` }}"
         SECRET_MQTT_PASSWORD: "{{ `{{ .HOME_ASSISTANT_PASSWORD }}` }}"
-        SECRET_MQTT_HOST: "mqtt://vernemq.ha-vernemq.svc.cluster.local"
+        SECRET_MQTT_HOST: "mqtt://home-assistant-mqtt-rmq.ha-rabbitmq.svc.cluster.local"
         S3_ACCESS_KEY_ID: "{{ `{{ .S3_ACCESS_KEY }}` }}"
         S3_ACCESS_SECRET_KEY: "{{ `{{ .S3_SECRET_KEY }}` }}"
   data:


### PR DESCRIPTION
## Summary
- Repoints Home Assistant's MQTT connection from VerneMQ to the new RabbitMQ instance

## Test plan
- [ ] After merge: Home Assistant pod restarts cleanly
- [ ] After merge: MQTT integration shows connected in Home Assistant's Settings > Devices & Services
- [ ] After merge: existing MQTT-discovered devices/entities reappear (spot-check a few)
- [ ] VerneMQ left running and untouched — this PR only repoints the client, so rollback is a one-line revert if anything looks wrong