### PR TITLE
fix(resources): right-size over-provisioned CPU/memory requests

### DIFF
--- a/.plans/TODO.md
+++ b/.plans/TODO.md
@@ -13,6 +13,13 @@ General backlog items not tied to a specific migration plan.
   - Other clusters (`litellm`, `gitea`, `keycloak`) use the deprecated plain `17.X` rolling tags — should also migrate to `standard` + plugin
   - Ref: https://github.com/cloudnative-pg/plugin-barman-cloud
 
+## Infrastructure — Logging
+
+- [ ] **No centralized log aggregation exists** — `monitoring` namespace is metrics-only (kube-prometheus-stack + smartctl-exporter), no Loki/Promtail/Fluent Bit/Vector anywhere in the cluster
+  - Surfaced while disabling rook-ceph's `logCollector` (PR #4468) to reclaim ~1.3 cores/1.3Gi of idle reservation — without it, Ceph component logs are `kubectl logs`-only (ephemeral, lost on restart/rotation)
+  - Accepted as a tradeoff for now; revisit if Ceph log history is ever needed for debugging a real incident
+  - If pursued, a lightweight option (e.g. Grafana Loki + Promtail/Alloy) would also benefit every other app in the cluster, not just rook-ceph
+
 ## Apps — Chart Upgrades
 
 - [ ] **Jellyfin** — migrate from local custom chart to official `jellyfin/jellyfin` Helm chart

--- a/cluster/apps/ai/coder/workspace-template/main.tf
+++ b/cluster/apps/ai/coder/workspace-template/main.tf
@@ -149,8 +149,8 @@ resource "kubernetes_deployment_v1" "workspace" {
 
           resources {
             requests = {
-              cpu    = "500m"
-              memory = "1Gi"
+              cpu    = "100m"
+              memory = "128Mi"
             }
             limits = {
               cpu    = "1000m"

--- a/cluster/apps/core/rook-ceph/cluster/values.yaml
+++ b/cluster/apps/core/rook-ceph/cluster/values.yaml
@@ -30,6 +30,8 @@ rook-ceph-cluster:
       modules:
         - name: rook
           enabled: true
+    logCollector:
+      enabled: false
     resources:
       mgr:
         requests:

--- a/cluster/apps/core/rook-ceph/csi-drivers/values.yaml
+++ b/cluster/apps/core/rook-ceph/csi-drivers/values.yaml
@@ -11,38 +11,38 @@ ceph-csi-drivers:
         resources:
           provisioner:
             requests:
-              memory: 128Mi
-              cpu: 25m
+              memory: 32Mi
+              cpu: 10m
             limits:
               memory: 256Mi
           resizer:
             requests:
-              memory: 128Mi
-              cpu: 25m
+              memory: 32Mi
+              cpu: 10m
             limits:
               memory: 256Mi
           attacher:
             requests:
-              memory: 128Mi
-              cpu: 25m
+              memory: 32Mi
+              cpu: 10m
             limits:
               memory: 256Mi
           snapshotter:
             requests:
-              memory: 128Mi
-              cpu: 25m
+              memory: 32Mi
+              cpu: 10m
             limits:
               memory: 256Mi
           plugin:
             requests:
-              memory: 512Mi
-              cpu: 50m
+              memory: 128Mi
+              cpu: 20m
             limits:
               memory: 1Gi
           omapGenerator:
             requests:
-              memory: 512Mi
-              cpu: 50m
+              memory: 128Mi
+              cpu: 20m
             limits:
               memory: 1Gi
           liveness: {}
@@ -52,14 +52,14 @@ ceph-csi-drivers:
         resources:
           plugin:
             requests:
-              memory: 512Mi
-              cpu: 250m
+              memory: 128Mi
+              cpu: 50m
             limits:
               memory: 1Gi
           registrar:
             requests:
-              memory: 128Mi
-              cpu: 50m
+              memory: 32Mi
+              cpu: 10m
             limits:
               memory: 256Mi
           liveness: {}
@@ -72,32 +72,32 @@ ceph-csi-drivers:
         resources:
           provisioner:
             requests:
-              memory: 128Mi
-              cpu: 25m
+              memory: 32Mi
+              cpu: 10m
             limits:
               memory: 256Mi
           resizer:
             requests:
-              memory: 128Mi
-              cpu: 25m
+              memory: 32Mi
+              cpu: 10m
             limits:
               memory: 256Mi
           attacher:
             requests:
-              memory: 128Mi
-              cpu: 25m
+              memory: 32Mi
+              cpu: 10m
             limits:
               memory: 256Mi
           snapshotter:
             requests:
-              memory: 128Mi
-              cpu: 25m
+              memory: 32Mi
+              cpu: 10m
             limits:
               memory: 256Mi
           plugin:
             requests:
-              memory: 512Mi
-              cpu: 50m
+              memory: 128Mi
+              cpu: 20m
             limits:
               memory: 1Gi
           omapGenerator: {}
@@ -108,14 +108,14 @@ ceph-csi-drivers:
         resources:
           plugin:
             requests:
-              memory: 512Mi
-              cpu: 250m
+              memory: 128Mi
+              cpu: 50m
             limits:
               memory: 1Gi
           registrar:
             requests:
-              memory: 128Mi
-              cpu: 50m
+              memory: 32Mi
+              cpu: 10m
             limits:
               memory: 256Mi
           liveness: {}

--- a/cluster/apps/system/envoy-gateweay/templates/envoy.yaml
+++ b/cluster/apps/system/envoy-gateweay/templates/envoy.yaml
@@ -17,6 +17,7 @@ spec:
           resources:
             requests:
               cpu: 100m
+              memory: 128Mi
             limits:
               memory: 1Gi
       envoyService:


### PR DESCRIPTION
## Summary

A resource audit (per-node requests vs. `kubectl top` actual usage) found mc2 pinned at 97% CPU/memory *requests* while real usage was only 34-45% — new apps were being blocked by reservations, not actual scarcity. This trims the biggest offenders without touching resource *limits* (no burst capacity lost):

- **rook-ceph log-collector**: disabled (`cephClusterSpec.logCollector.enabled: false`). 13 sidecars reserved ~1.3 cores / 1.3Gi total, actual usage ~0. **Correction from an earlier version of this description**: the cluster has no centralized log aggregation (no Loki/Promtail/Fluent Bit anywhere), so this is a real tradeoff, not redundant cleanup — Ceph component logs become `kubectl logs`-only (ephemeral) instead of persisted to the host. Accepted as a tradeoff; tracked as a follow-up in `.plans/TODO.md`.
- **rook-ceph CSI plugins/sidecars** (rbd + cephfs, controller + node): requests reduced across `plugin`, `registrar`, `provisioner`, `resizer`, `attacher`, `snapshotter`. Was reserving ~1.8 cores / 5.9Gi, actual usage ~20m / 530Mi.
- **envoy-gateway proxy**: added an explicit `128Mi` memory request (previously unset, so it defaulted to the 1Gi limit across 4 pods). Actual usage measured at 26-84Mi/pod.
- **coder workspace template**: default per-workspace request dropped from `500m/1Gi` to `100m/128Mi` (limits unchanged at `1000m/2Gi` for burst). Actual idle usage measured at ~1-2m / 30-44Mi.

Explicitly **not** touched: rook-ceph `mgr`/`mon` requests, which were found to run slightly *above* their current request (a separate, lower-priority follow-up).

## Verification

- `helm template` rendered cleanly for `rook-ceph/cluster`, `rook-ceph/csi-drivers`, and `envoy-gateweay`, confirming the new values land in the `CephCluster`, `Driver`, and `EnvoyProxy` manifests as expected.
- `terraform validate` passed for the coder workspace template.
- `task lint:all` shows only pre-existing warnings unrelated to these files.

## Test plan

- [ ] ArgoCD sync rook-ceph `cluster` app, confirm `logCollector` sidecars disappear from `rook-ceph` pods and Ceph health stays `HEALTH_OK`
- [ ] ArgoCD sync rook-ceph `csi-drivers` app, confirm CSI pods restart with new (lower) requests and PVC mount/provision/resize/snapshot still work
- [ ] ArgoCD sync `envoy-gateweay`, confirm proxy pods restart with the new memory request and routing is unaffected
- [ ] `coder templates push` the updated workspace-template (Terraform, not GitOps-managed) — only affects newly created/restarted workspaces
- [ ] Re-run the resource audit after a day to confirm mc2 request % has dropped meaningfully