### PR TITLE
fix(rook-ceph): right-size mgr/mon/osd/mgr-sidecar resource requests

### DIFF
--- a/cluster/apps/core/rook-ceph/cluster/values.yaml
+++ b/cluster/apps/core/rook-ceph/cluster/values.yaml
@@ -35,26 +35,26 @@ rook-ceph-cluster:
     resources:
       mgr:
         requests:
-          cpu: "125m"
-          memory: "549M"
+          cpu: "50m"
+          memory: "800M"
         limits:
           memory: "1219M"
       mon:
         requests:
           cpu: "49m"
-          memory: "477M"
+          memory: "700M"
         limits:
           memory: "1059M"
       osd:
         requests:
-          cpu: "442m"
+          cpu: "150m"
           memory: "2678M"
         limits:
           memory: "5944M"
       mgr-sidecar:
         requests:
-          cpu: "49m"
-          memory: "94M"
+          cpu: "40m"
+          memory: "32M"
         limits:
           memory: "208M"
       crashcollector:


### PR DESCRIPTION
## Summary

Follow-up to #4468, which deliberately skipped these to keep that PR focused. Re-auditing per-node requests vs. actual usage surfaced two directions of drift in rook-ceph's core Ceph daemons (compared against mature-uptime `kubectl top` data, not a cold-start snapshot right after a pod restart, which understates memory before bluestore/rocksdb caches and PG stats warm up):

- **Under-requested memory (risk):** `mgr-a` (active) hit 1017Mi actual against a 549M request; `mon-g` hit 650Mi against a 477M request. Both were running above their reservation.
- **Over-requested CPU:** `osd` requested 442m against ~30-58m actual (consistent across two independent snapshots); `mgr` requested 125m against ~17-43m actual.
- **Over-requested memory:** `mgr-sidecar` (watch-active) requested 94M against ~10-11Mi actual.

| Component | Before | After |
|---|---|---|
| mgr | 125m / 549M | 50m / 800M |
| mon | 49m / 477M | 49m / 700M |
| osd | 442m / 2678M | 150m / 2678M |
| mgr-sidecar | 49m / 94M | 40m / 32M |

Memory *limits* on mgr/mon/osd, and mds/crashcollector requests, are untouched — already well-matched to observed usage.

## Verification

- `helm template rook-ceph-cluster . -f values.yaml --skip-crds` rendered cleanly; confirmed the new values land correctly in the `CephCluster` manifest's `spec.resources` block.
- `task lint:all` shows no new warnings for this file.

## Test plan

- [ ] ArgoCD sync rook-ceph `cluster` app
- [ ] Confirm mgr/mon/osd pods restart cleanly with new requests and Ceph health stays `HEALTH_OK`
- [ ] Watch `kubectl top` for mgr/mon over a few days of real uptime to confirm the new memory requests hold (not just the immediate post-restart numbers)