### PR TITLE
fix: bump dragonfly chart default memory limit to fix startup crash

### DIFF
--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: dragonfly
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/charts/dragonfly/values.yaml
+++ b/charts/dragonfly/values.yaml
@@ -5,7 +5,7 @@ resources:
     memory: 128Mi
     cpu: 50m
   limits:
-    memory: 256Mi
+    memory: 512Mi
     cpu: 250m
 authentication:
   existingSecret: ""

--- a/cluster/apps/system/oauth2-proxy/Chart.yaml
+++ b/cluster/apps/system/oauth2-proxy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 10.7.0
     repository: https://oauth2-proxy.github.io/manifests
   - name: dragonfly
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../../../../charts/dragonfly/


### PR DESCRIPTION
## Summary
- Fixes a startup crash-loop in every Dragonfly instance (found live in `oauth2-proxy-dragonfly-0` after merging #4482): Dragonfly hard-exits when `maxmemory < threads * 256MB`, and its default heuristic sets `maxmemory` to 80% of the container's memory *limit* — the chart's previous `256Mi` limit produced `204.8Mi`, below the floor for even 1 IO thread.
- Bumps `charts/dragonfly`'s default `resources.limits.memory` from `256Mi` to `512Mi` (`0.8 * 512Mi ≈ 409.6Mi`, comfortably above the floor).
- Bumps the chart's own version (`1.0.0` → `1.0.1`) and the `oauth2-proxy` app's pinned dependency version, so a cached local chart tarball doesn't silently mask the fix — same pinning convention this repo already uses for `pgsql-cnpg`.

Root cause confirmed directly from `oauth2-proxy-dragonfly-0`'s crash logs:
```
Found 256.00MiB available memory. Setting maxmemory to 204.80MiB
There are 1 threads, so 256.00MiB are required. Exiting...
```
oauth2-proxy's own pod was crash-looping too, but purely as a downstream effect (`no route to host` — the Dragonfly Service had no ready endpoints because the pod never passed its liveness probe).

## Test plan
- [x] `helm template` on `charts/dragonfly` standalone and on `oauth2-proxy` as a consumer, confirmed rendered `spec.resources.limits.memory: 512Mi` (done locally)
- [x] Confirmed the version bump forces a fresh local dependency build rather than reusing a stale cached tarball
- [ ] After merge: confirm `oauth2-proxy-dragonfly-0` starts and stays `1/1 Running` (no crash-loop)
- [ ] After merge: confirm oauth2-proxy's own pod stops crash-looping and a login round-trip works