### PR TITLE
feat: migrate Nextcloud redis to Dragonfly

### DIFF
--- a/cluster/apps/default/nextcloud/app/Chart.yaml
+++ b/cluster/apps/default/nextcloud/app/Chart.yaml
@@ -11,3 +11,6 @@ dependencies:
   - name: pgsql-cnpg
     version: 1.3.2
     repository: file://../../../../../charts/pgsql-cnpg/
+  - name: dragonfly
+    version: 1.0.1
+    repository: file://../../../../../charts/dragonfly/

--- a/cluster/apps/default/nextcloud/app/values.yaml
+++ b/cluster/apps/default/nextcloud/app/values.yaml
@@ -100,26 +100,21 @@ nextcloud:
       secretName: nextclouddb-cnpg-app
       usernameKey: username
       passwordKey: password
-  # NOTE: chart 9.2.0's templates/_helpers.tpl `nextcloud.env.redis` takes the
-  # `redis.enabled` branch whenever it is true, completely ignoring `externalRedis.*`
-  # (that block only applies when `redis.enabled: false`). So there is no
-  # `externalRedis` section here — it would be dead configuration that misleadingly
-  # implies a secretKeyRef-based password lookup that never happens.
-  #
-  # With `redis.enabled: true`, the bundled Bitnami Redis subchart deploys its own
-  # in-cluster, ClusterIP-only Redis (service `nextcloud-redis-master`). Setting
-  # `auth.existingSecret` below (verified via `helm template` against the subchart's
-  # templates/secret.yaml + _helpers.tpl `redis.secretName`/`redis.secretPasswordKey`)
-  # suppresses the subchart's own auto-generated Secret and makes both the Redis
-  # server (StatefulSet) and the Nextcloud app container's REDIS_HOST_PASSWORD env var
-  # read the password from the same ExternalSecret-managed Secret below, so no
-  # plaintext credential is committed here.
+  # Redis is now provided by a per-app Dragonfly instance (see `dragonfly:` block
+  # below), not the bundled Bitnami subchart. Setting `redis.enabled: false` makes
+  # `nextcloud.env.redis` take the `externalRedis` branch instead (confirmed via
+  # the chart's templates/_helpers.tpl) so REDIS_HOST/REDIS_HOST_PORT/REDIS_HOST_PASSWORD
+  # get wired to the Dragonfly service below.
   redis:
+    enabled: false
+  externalRedis:
     enabled: true
-    auth:
+    host: nextcloud-dragonfly
+    port: 6379
+    existingSecret:
       enabled: true
-      existingSecret: nextcloud-redis-auth
-      existingSecretPasswordKey: redis-password
+      secretName: nextcloud-redis-auth
+      passwordKey: redis-password
   nginx:
     enabled: true
   persistence:
@@ -154,3 +149,9 @@ nextcloud:
               add:
                 - name: strict-transport-security
                   value: max-age=31536000
+
+dragonfly:
+  name: nextcloud
+  authentication:
+    existingSecret: nextcloud-redis-auth
+    existingSecretKey: redis-password

--- a/docs/superpowers/plans/2026-07-08-dragonfly-operator.md
+++ b/docs/superpowers/plans/2026-07-08-dragonfly-operator.md
@@ -8,6 +8,14 @@
 
 **Tech Stack:** Helm (OCI dependency), Dragonfly Operator v1.6.1 (`dragonflydb.io/v1alpha1` `Dragonfly` CRD), External Secrets Operator + Bitwarden `ClusterSecretStore`, ArgoCD ApplicationSet.
 
+## Status: In Progress
+
+Tasks 1-3 merged (PR [#4482](https://github.com/mmalyska/home-ops/pull/4482)). Task 4 in progress.
+
+**Deviation, found during Task 3 live verification (systematic-debugging):** `oauth2-proxy-dragonfly-0` crash-looped in production after #4482 merged. Root cause, confirmed directly from its logs (`There are 1 threads, so 256.00MiB are required. Exiting...`): Dragonfly hard-exits at boot when `maxmemory < threads * 256MB`; its default heuristic sets `maxmemory` to 80% of the container's memory *limit*; `charts/dragonfly`'s original default limit of `256Mi` (Task 2) produced `204.8Mi` — below the floor for even 1 thread. This is a chart-level defect affecting every instance, not just oauth2-proxy — oauth2-proxy's own pod crash-loop was purely downstream (`no route to host`, no ready Service endpoints). Fixed in PR [#4484](https://github.com/mmalyska/home-ops/pull/4484): bumped `charts/dragonfly`'s default `resources.limits.memory` to `512Mi`, and bumped the chart's own version `1.0.0` → `1.0.1` (propagated to every consumer's pinned dependency version below) so a cached local chart tarball can't silently mask the fix — same pinning convention this repo already uses for `pgsql-cnpg`. Live-verified healthy post-merge.
+
+**Takeaway applied going forward:** the `dragonfly` dependency version below reads `1.0.1`, not the `1.0.0` originally written for this plan — already corrected in Tasks 4-6's text.
+
 ## Global Constraints
 
 - Never mutate live cluster state (kubectl apply/delete, ArgoCD sync) without explicit user confirmation — changes land via PR + ArgoCD auto-sync, not manual `kubectl apply`.
@@ -339,7 +347,7 @@ dependencies:
     version: 1.3.2
     repository: file://../../../../../charts/pgsql-cnpg/
   - name: dragonfly
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../../../../../charts/dragonfly/
 ```
 
@@ -479,7 +487,7 @@ dependencies:
     version: 1.3.2
     repository: file://../../../../charts/pgsql-cnpg/
   - name: dragonfly
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../../../../charts/dragonfly/
 ```
 
@@ -612,7 +620,7 @@ dependencies:
     version: 1.3.2
     repository: file://../../../../charts/pgsql-cnpg/
   - name: dragonfly
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../../../../charts/dragonfly/
 ```
 


### PR DESCRIPTION
## Summary
- Replaces Nextcloud's bundled Bitnami redis subchart with a Dragonfly instance via the operator
- Reuses the existing `nextcloud-redis-auth`/`redis-password` Bitwarden-backed secret, no new secrets needed
- Depends on `charts/dragonfly` at `1.0.1` (includes the memory-limit fix from PR #4484 — see `docs/superpowers/plans/2026-07-08-dragonfly-operator.md`'s Status section for that incident)

## Test plan
- [x] `helm template` renders clean, confirmed REDIS_HOST/REDIS_HOST_PORT/REDIS_HOST_PASSWORD wiring and the Dragonfly CR's 512Mi memory limit (done locally, see commits)
- [ ] After merge: confirm `nextcloud-dragonfly` pod healthy (1/1 Running, no crash-loop) in `nextcloud` namespace
- [ ] After merge: confirm Nextcloud pod restarts cleanly and connects to the new Dragonfly instance (check logs for redis connection errors)
- [ ] After merge: Nextcloud web UI loads, login works, file browsing works (exercises the cache/locking path)
- [ ] After merge: confirm old Bitnami redis StatefulSet/Service/PVC are gone (no orphaned resources)