### PR TITLE
feat: wire Gitea for Dragonfly

### DIFF
--- a/cluster/apps/core/argocd/resources/cluster-secrets-externalsecret.yaml
+++ b/cluster/apps/core/argocd/resources/cluster-secrets-externalsecret.yaml
@@ -93,3 +93,6 @@ spec:
     - secretKey: daytona-oidc-client-secret
       remoteRef:
         key: "84c913e2-e00c-494f-9391-b45d00fad1fa" #gitleaks:allow #DAYTONA_OIDC_CLIENT_SECRET
+    - secretKey: gitea-dragonfly-password
+      remoteRef:
+        key: "8079ea1a-bdc1-41f2-b34a-b48100bd40c0" #gitleaks:allow #GITEA_DRAGONFLY_PASSWORD

--- a/cluster/apps/default/gitea/Chart.yaml
+++ b/cluster/apps/default/gitea/Chart.yaml
@@ -11,3 +11,6 @@ dependencies:
   - name: pgsql-cnpg
     version: 1.3.2
     repository: file://../../../../charts/pgsql-cnpg/
+  - name: dragonfly
+    version: 1.0.1
+    repository: file://../../../../charts/dragonfly/

--- a/cluster/apps/default/gitea/templates/dragonfly-externalsecret.yaml
+++ b/cluster/apps/default/gitea/templates/dragonfly-externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gitea-dragonfly-auth
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  refreshInterval: 1h
+  target:
+    name: gitea-dragonfly-auth
+    creationPolicy: Owner
+  data:
+    - secretKey: redis-password
+      remoteRef:
+        key: "8079ea1a-bdc1-41f2-b34a-b48100bd40c0" #gitleaks:allow #GITEA_DRAGONFLY_PASSWORD

--- a/cluster/apps/default/gitea/values.yaml
+++ b/cluster/apps/default/gitea/values.yaml
@@ -51,15 +51,15 @@ gitea:
         MAX_AGE: 10m
         ALLOW_CREDENTIALS: false
       session:
-        PROVIDER: redis-cluster
-        PROVIDER_CONFIG: redis+cluster://:gitea@gitea-redis-cluster-headless.gitea.svc.cluster.local:6379/0?pool_size=100&idle_timeout=180s&
+        PROVIDER: redis
+        PROVIDER_CONFIG: redis://:<secret:gitea-dragonfly-password>@gitea-dragonfly.gitea.svc.cluster.local:6379/0?pool_size=100&idle_timeout=180s&
       cache:
         ENABLED: true
-        ADAPTER: redis-cluster
-        HOST: redis+cluster://:gitea@gitea-redis-cluster-headless.gitea.svc.cluster.local:6379/0?pool_size=100&idle_timeout=180s&
+        ADAPTER: redis
+        HOST: redis://:<secret:gitea-dragonfly-password>@gitea-dragonfly.gitea.svc.cluster.local:6379/0?pool_size=100&idle_timeout=180s&
       queue:
         TYPE: redis
-        CONN_STR: redis+cluster://:gitea@gitea-redis-cluster-headless.gitea.svc.cluster.local:6379/0?pool_size=100&idle_timeout=180s&
+        CONN_STR: redis://:<secret:gitea-dragonfly-password>@gitea-dragonfly.gitea.svc.cluster.local:6379/0?pool_size=100&idle_timeout=180s&
   ingress:
     enabled: false
   postgresql:
@@ -67,7 +67,7 @@ gitea:
   valkey-cluster:
     enabled: false
   valkey:
-    enabled: true
+    enabled: false
   postgresql-ha:
     enabled: false
   persistence:
@@ -139,3 +139,8 @@ pgsql-cnpg:
   #       name: barman-cloud.cloudnative-pg.io
   #       parameters:
   #         barmanObjectName: giteadb-objectstore
+dragonfly:
+  name: gitea
+  authentication:
+    existingSecret: gitea-dragonfly-auth
+    existingSecretKey: redis-password

--- a/cluster/apps/default/harbor/Chart.yaml
+++ b/cluster/apps/default/harbor/Chart.yaml
@@ -10,3 +10,6 @@ dependencies:
   - name: pgsql-cnpg
     version: 1.3.2
     repository: file://../../../../charts/pgsql-cnpg/
+  - name: dragonfly
+    version: 1.0.1
+    repository: file://../../../../charts/dragonfly/

--- a/cluster/apps/default/harbor/templates/dragonfly-externalsecret.yaml
+++ b/cluster/apps/default/harbor/templates/dragonfly-externalsecret.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: harbor-dragonfly-auth
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  refreshInterval: 1h
+  target:
+    name: harbor-dragonfly-auth
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        REDIS_PASSWORD: "{{ `{{ .password }}` }}"
+        password: "{{ `{{ .password }}` }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: "e6560beb-d2d1-4b2e-b5e8-b48100bb161f" #gitleaks:allow #HARBOR_DRAGONFLY_PASSWORD

--- a/cluster/apps/default/harbor/values.yaml
+++ b/cluster/apps/default/harbor/values.yaml
@@ -47,7 +47,10 @@ harbor:
       sslmode: require
 
   redis:
-    type: internal
+    type: external
+    external:
+      addr: "harbor-dragonfly:6379"
+      existingSecret: harbor-dragonfly-auth
 
   trivy:
     enabled: false
@@ -88,3 +91,9 @@ pgsql-cnpg:
         immediate: true
         schedule: "5 0 0 * * *"
         backupOwnerReference: self
+
+dragonfly:
+  name: harbor
+  authentication:
+    existingSecret: harbor-dragonfly-auth
+    existingSecretKey: password


### PR DESCRIPTION
## Summary
- Replaces Gitea's bundled `valkey` subchart with a Dragonfly instance via the operator
- Fixes a pre-existing hardcoded plaintext redis password (`:gitea@...`) as a side effect
- Adds a new token entry (`gitea-dragonfly-password`) to the repo's central `cluster-secrets` ExternalSecret, alongside a per-app ExternalSecret for the Dragonfly CR's own authentication — both backed by the same new Bitwarden entry (`GITEA_DRAGONFLY_PASSWORD`)
- Gitea is currently `enabled: false` — this is prep work, not a live cutover; live verification happens whenever Gitea is next enabled
- Depends on `charts/dragonfly` at `1.0.1` (memory-limit fix from PR #4484)

**Note:** this branch is stacked on top of #4486 (Harbor, not yet merged) — the diff will show Harbor's changes too until that merges, then narrow to just this PR's Gitea changes automatically.

## Test plan
- [x] `helm template` renders clean, confirmed all three connection strings, the central secrets file entry, and the per-app ExternalSecret (done locally, see commits + task review)
- [ ] No live verification — app is disabled. Re-verify when Gitea is next enabled.