### PR TITLE
fix(cnpg): reduce backup storage bloat on QNAP S3

### DIFF
--- a/.plans/TODO.md
+++ b/.plans/TODO.md
@@ -32,15 +32,15 @@ General backlog items not tied to a specific migration plan.
 
 Surfaced 2026-07-20 investigating a QNAP "storage near empty" alert. Total CNPG backup usage was ~210 GiB against <2 GiB of live data per cluster. Full breakdown/numbers are in conversation history from that date; items below are the unimplemented mitigations.
 
-- [ ] **Fix coder's malformed `ScheduledBackup` cron** — `cluster/apps/ai/coder/values.yaml:78` sets `schedule: "0 2 * * *"` (5-field), while every other CNPG app uses the required 6-field format (`sec min hour day month dow`, e.g. `"5 0 0 * * *"`). The plugin's cron parser misinterprets the missing field and runs backups **every hour** instead of daily — confirmed live (`ScheduledBackup.status.nextScheduleTime` was exactly 1h after `lastScheduleTime`). Over 10 days this produced ~240 base backups instead of 10 and is the single largest contributor to coder's 74.7 GiB S3 footprint (vs. 814 MB live DB). Fix: `"0 0 2 * * *"`.
+- [x] **Fix coder's malformed `ScheduledBackup` cron** — was a 5-field cron (`"0 2 * * *"`) misparsed as hourly instead of daily. Fixed to `"0 0 2 * * *"` on branch `fix/cnpg-backup-storage-bloat`.
 
-- [ ] **Raise `archive_timeout` from 5min on low-traffic CNPG clusters** — every `Cluster` forces a full 16 MB WAL segment to S3 every 5 minutes regardless of actual write activity (confirmed live in `nextclouddb-cnpg`'s barman-cloud sidecar logs — `Archived WAL file` firing every ~5min with near-zero app usage). At 288 segments/day × 10-day retention this alone accounts for ~45 GiB of nearly-empty WAL each for `honcho` and `nextcloud` (both <1 GiB live data). Raise to 15-30min for apps without a tight RPO; 2-instance streaming replication already covers primary durability.
+- [x] **Raise `archive_timeout` from 5min on low-traffic CNPG clusters** — set to `30min` as a chart-level default in `charts/pgsql-cnpg/values.yaml` (`postgresql.parameters.archive_timeout`), applied uniformly to all CNPG clusters rather than per-app, on branch `fix/cnpg-backup-storage-bloat`.
 
-- [ ] **Enable compression on all CNPG `ObjectStore`s** — `data.compression` and `wal.compression` are unset on every `ObjectStore` in the cluster (barman-cloud plugin supports gzip/bzip2/snappy). Free additional reduction stacked on top of the two fixes above.
+- [x] **Enable compression on all CNPG `ObjectStore`s** — `data.compression`/`wal.compression: gzip` added as a chart-level default (merged into each app's `objectStore:` block via `mergeOverwrite` in `charts/pgsql-cnpg/templates/cnpg.yaml`, app-specific values still win if ever overridden), on branch `fix/cnpg-backup-storage-bloat`. Same branch also centralized the repeated `instanceSidecarConfiguration` (AWS checksum env vars) into the chart as a default, removing it from all 10 per-app `values.yaml` files — this was the exact class of repetition bug that caused coder's cron/config to drift in the first place.
 
-- [ ] **Delete orphaned CNPG backup prefixes on QNAP S3** — `s3://k8s-at-home-backup/cnpg/{daytona,firefly,harbor,home-assistant,litellm}/` (~2.75 GiB total) have no corresponding active `Cluster` resource anywhere in the cluster — leftover from decommissioned/migrated apps. Confirm each app is genuinely gone (not just moved off CNPG) before deleting.
+- [ ] **Re-evaluate `retentionPolicy: 10d` per app** — deferred until the effect of the above fixes on actual S3 usage is visible (barman-cloud plugin has no incremental/differential backup support today, so this is a straight days-retained tradeoff).
 
-- [ ] **Re-evaluate `retentionPolicy: 10d` per app** — once the above land, decide whether 10 days of daily full backups (barman-cloud plugin has no incremental/differential support today) is still the right default everywhere, or whether lower-value apps can go shorter.
+Dropped: deleting orphaned CNPG backup prefixes on QNAP S3 (`daytona`, `firefly`, `harbor`, `home-assistant`, `litellm`) — decided against; those apps may be re-enabled and restored from those backups someday.
 
 ## Infrastructure — Logging
 

--- a/charts/pgsql-cnpg/Chart.yaml
+++ b/charts/pgsql-cnpg/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: pgsql-cnpg
 type: application
-version: 1.3.2
+version: 1.4.0

--- a/charts/pgsql-cnpg/templates/cnpg.yaml
+++ b/charts/pgsql-cnpg/templates/cnpg.yaml
@@ -27,6 +27,11 @@ spec:
       pgaudit.log_catalog: "off"
       pgaudit.log_parameter: "on"
       pgaudit.log_relation: "on"
+      {{- with .Values.postgresql }}
+      {{- with .parameters }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- end }}
   {{- with .Values.bootstrap }}
   bootstrap:
     {{- toYaml . | nindent 4 }}
@@ -54,7 +59,8 @@ metadata:
   name: {{ printf "%s-objectstore" .Values.name }}
 spec:
   configuration:
-    {{- toYaml .Values.objectStore | nindent 4 }}
+    {{- $compressionDefaults := dict "data" (dict "compression" "gzip") "wal" (dict "compression" "gzip") }}
+    {{- toYaml (mergeOverwrite $compressionDefaults .Values.objectStore) | nindent 4 }}
   {{- if .Values.retentionPolicy }}
   retentionPolicy: {{ .Values.retentionPolicy }}
   {{- end }}

--- a/charts/pgsql-cnpg/values.yaml
+++ b/charts/pgsql-cnpg/values.yaml
@@ -14,6 +14,23 @@ storage:
 # #         barmanObjectName: <name>-objectstore
 monitoring:
   enablePodMonitor: true
+# Default sidecar env for every CNPG cluster's barman-cloud plugin — required
+# for reliable S3 uploads against some S3-compatible backends. Override per
+# app only if a specific cluster needs something different.
+instanceSidecarConfiguration:
+  env:
+    - name: AWS_REQUEST_CHECKSUM_CALCULATION
+      value: when_required
+    - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+      value: when_required
+# Default archive_timeout — CNPG's own built-in default is 5min, which forces
+# a full WAL segment to S3 every 5 minutes regardless of actual write
+# activity. 30min cuts that churn substantially while still being backed by
+# 2-instance streaming replication for primary durability. Override per app
+# if a specific cluster needs a tighter RPO.
+postgresql:
+  parameters:
+    archive_timeout: "30min"
 # retentionPolicy: "10d"
 # objectStore:
 #   destinationPath: "s3://bucket/cnpg/<name>"

--- a/cluster/apps/ai/coder/Chart.yaml
+++ b/cluster/apps/ai/coder/Chart.yaml
@@ -7,5 +7,5 @@ dependencies:
     version: 2.35.2
     repository: https://helm.coder.com/v2
   - name: pgsql-cnpg
-    version: 1.3.2
+    version: 1.4.0
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/ai/coder/values.yaml
+++ b/cluster/apps/ai/coder/values.yaml
@@ -58,10 +58,6 @@ pgsql-cnpg:
   monitoring:
     enablePodMonitor: true
   retentionPolicy: "10d"
-  instanceSidecarConfiguration:
-    env:
-      - name: AWS_REQUEST_CHECKSUM_CALCULATION
-        value: when_required
   objectStore:
     destinationPath: "s3://k8s-at-home-backup/cnpg/coder"
     endpointURL: <secret:s3_endpoint>
@@ -75,6 +71,6 @@ pgsql-cnpg:
   scheduledBackups:
     - name: coderdb-backup
       spec:
-        schedule: "0 2 * * *"
+        schedule: "0 0 2 * * *"
         backupOwnerReference: self
         immediate: true

--- a/cluster/apps/ai/honcho/Chart.yaml
+++ b/cluster/apps/ai/honcho/Chart.yaml
@@ -5,5 +5,5 @@ type: application
 version: 1.0.0
 dependencies:
   - name: pgsql-cnpg
-    version: 1.3.2
+    version: 1.4.0
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/ai/honcho/values.yaml
+++ b/cluster/apps/ai/honcho/values.yaml
@@ -58,12 +58,6 @@ pgsql-cnpg:
       secretAccessKey:
         name: honcho-secrets
         key: S3_ACCESS_SECRET_KEY
-  instanceSidecarConfiguration:
-    env:
-      - name: AWS_REQUEST_CHECKSUM_CALCULATION
-        value: when_required
-      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
-        value: when_required
   scheduledBackups:
     - name: honchodb-cnpg-backup
       spec:

--- a/cluster/apps/ai/litellm/Chart.yaml
+++ b/cluster/apps/ai/litellm/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
     version: 1.93.0
     repository: oci://ghcr.io/berriai
   - name: pgsql-cnpg
-    version: 1.3.2
+    version: 1.4.0
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/ai/litellm/values.yaml
+++ b/cluster/apps/ai/litellm/values.yaml
@@ -92,12 +92,6 @@ pgsql-cnpg:
       secretAccessKey:
         name: litellm-secrets
         key: S3_ACCESS_SECRET_KEY
-  instanceSidecarConfiguration:
-    env:
-      - name: AWS_REQUEST_CHECKSUM_CALCULATION
-        value: when_required
-      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
-        value: when_required
   scheduledBackups:
     - name: litelldb-cnpg-backup
       spec:

--- a/cluster/apps/default/bookorbit/Chart.yaml
+++ b/cluster/apps/default/bookorbit/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
     version: 5.0.1
     repository: https://bjw-s-labs.github.io/helm-charts
   - name: pgsql-cnpg
-    version: 1.3.2
+    version: 1.4.0
     repository: file://../../../../charts/pgsql-cnpg/
   - name: volsync
     version: 1.0.0

--- a/cluster/apps/default/bookorbit/values.yaml
+++ b/cluster/apps/default/bookorbit/values.yaml
@@ -161,12 +161,6 @@ pgsql-cnpg:
       secretAccessKey:
         name: bookorbit-secrets
         key: S3_ACCESS_SECRET_KEY
-  instanceSidecarConfiguration:
-    env:
-      - name: AWS_REQUEST_CHECKSUM_CALCULATION
-        value: when_required
-      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
-        value: when_required
   retentionPolicy: "10d"
   scheduledBackups:
     - name: bookorbdb-cnpg-backup

--- a/cluster/apps/default/gitea/Chart.yaml
+++ b/cluster/apps/default/gitea/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 12.7.0
     repository: https://dl.gitea.io/charts/
   - name: pgsql-cnpg
-    version: 1.3.2
+    version: 1.4.0
     repository: file://../../../../charts/pgsql-cnpg/
   - name: dragonfly
     version: 1.0.1

--- a/cluster/apps/default/gitea/values.yaml
+++ b/cluster/apps/default/gitea/values.yaml
@@ -117,12 +117,6 @@ pgsql-cnpg:
       secretAccessKey:
         name: gitea-secrets
         key: S3_ACCESS_SECRET_KEY
-  instanceSidecarConfiguration:
-    env:
-      - name: AWS_REQUEST_CHECKSUM_CALCULATION
-        value: when_required
-      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
-        value: when_required
   scheduledBackups:
     - name: giteadb-cnpg-backup
       spec:

--- a/cluster/apps/default/harbor/Chart.yaml
+++ b/cluster/apps/default/harbor/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
     version: 1.19.1
     repository: https://helm.goharbor.io
   - name: pgsql-cnpg
-    version: 1.3.2
+    version: 1.4.0
     repository: file://../../../../charts/pgsql-cnpg/
   - name: dragonfly
     version: 1.0.1

--- a/cluster/apps/default/harbor/values.yaml
+++ b/cluster/apps/default/harbor/values.yaml
@@ -86,12 +86,6 @@ pgsql-cnpg:
       secretAccessKey:
         name: harbor-s3-secret
         key: S3_ACCESS_SECRET_KEY
-  instanceSidecarConfiguration:
-    env:
-      - name: AWS_REQUEST_CHECKSUM_CALCULATION
-        value: when_required
-      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
-        value: when_required
   scheduledBackups:
     - name: harbordb-cnpg-backup
       spec:

--- a/cluster/apps/default/nextcloud/app/Chart.yaml
+++ b/cluster/apps/default/nextcloud/app/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 9.2.2
     repository: https://nextcloud.github.io/helm/
   - name: pgsql-cnpg
-    version: 1.3.2
+    version: 1.4.0
     repository: file://../../../../../charts/pgsql-cnpg/
   - name: dragonfly
     version: 1.0.1

--- a/cluster/apps/default/nextcloud/app/values.yaml
+++ b/cluster/apps/default/nextcloud/app/values.yaml
@@ -24,12 +24,6 @@ pgsql-cnpg:
       secretAccessKey:
         name: nextcloud-s3-secret
         key: S3_ACCESS_SECRET_KEY
-  instanceSidecarConfiguration:
-    env:
-      - name: AWS_REQUEST_CHECKSUM_CALCULATION
-        value: when_required
-      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
-        value: when_required
   scheduledBackups:
     - name: nextclouddb-cnpg-backup
       spec:

--- a/cluster/apps/default/nextcloud/onlyoffice/Chart.yaml
+++ b/cluster/apps/default/nextcloud/onlyoffice/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
     version: 1.0.4
     repository: file://../../../../../charts/onlyoffice-documentserver/
   - name: pgsql-cnpg
-    version: 1.3.2
+    version: 1.4.0
     repository: file://../../../../../charts/pgsql-cnpg/

--- a/cluster/apps/default/nextcloud/onlyoffice/values.yaml
+++ b/cluster/apps/default/nextcloud/onlyoffice/values.yaml
@@ -27,12 +27,6 @@ pgsql-cnpg:
       secretAccessKey:
         name: onlyoffice-s3-secret
         key: S3_ACCESS_SECRET_KEY
-  instanceSidecarConfiguration:
-    env:
-      - name: AWS_REQUEST_CHECKSUM_CALCULATION
-        value: when_required
-      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
-        value: when_required
   scheduledBackups:
     - name: onlyofficedb-cnpg-backup
       spec:

--- a/cluster/apps/home-automation/home-assistant/Chart.yaml
+++ b/cluster/apps/home-automation/home-assistant/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 5.0.1
     repository: https://bjw-s-labs.github.io/helm-charts
   - name: pgsql-cnpg
-    version: 1.3.2
+    version: 1.4.0
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/home-automation/home-assistant/values.yaml
+++ b/cluster/apps/home-automation/home-assistant/values.yaml
@@ -26,12 +26,6 @@ pgsql-cnpg:
       secretAccessKey:
         name: home-assistant-secret
         key: S3_ACCESS_SECRET_KEY
-  instanceSidecarConfiguration:
-    env:
-      - name: AWS_REQUEST_CHECKSUM_CALCULATION
-        value: when_required
-      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
-        value: when_required
   scheduledBackups:
     - name: home-assistant-cnpg-backup
       spec:

--- a/cluster/apps/system/keycloak/Chart.yaml
+++ b/cluster/apps/system/keycloak/Chart.yaml
@@ -6,5 +6,5 @@ version: 2.6.0
 appVersion: "17.0.1"
 dependencies:
   - name: pgsql-cnpg
-    version: 1.3.2
+    version: 1.4.0
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/system/keycloak/values.yaml
+++ b/cluster/apps/system/keycloak/values.yaml
@@ -108,12 +108,6 @@ pgsql-cnpg:
       secretAccessKey:
         name: keycloakdb-secrets
         key: S3_ACCESS_SECRET_KEY
-  instanceSidecarConfiguration:
-    env:
-      - name: AWS_REQUEST_CHECKSUM_CALCULATION
-        value: when_required
-      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
-        value: when_required
   scheduledBackups:
     - name: keycloakdb-cnpg-backup
       spec:


### PR DESCRIPTION
## Summary

Investigating a QNAP "storage near empty" alert found ~210 GiB of CNPG backups against <2 GiB of live data per cluster. Three causes, all fixed here:

- **coder's `ScheduledBackup` cron was malformed** (5-field instead of the required 6-field format) — silently misparsed as running *hourly* instead of daily, producing ~240 base backups instead of 10 over the retention window. Fixed to `"0 0 2 * * *"`.
- **`archive_timeout` was CNPG's built-in 5min default everywhere**, forcing a full 16 MB WAL segment to S3 every 5 minutes regardless of actual write activity. Now `30min`, set as a **chart-level default** in `charts/pgsql-cnpg` rather than per-app.
- **No `ObjectStore` had compression enabled.** Now `gzip` for both `data`/`wal`, also a chart-level default (merged into each app's `objectStore:` block, app-specific values still win if ever overridden).

While centralizing these as chart defaults, also folded the previously copy-pasted `instanceSidecarConfiguration` (AWS checksum env vars) into the same chart default and removed it from all 10 per-app `values.yaml` files — that repetition was the exact mechanism that let coder's config silently drift from every other app in the first place.

Chart bumped `pgsql-cnpg` 1.3.2 → 1.4.0; version pin updated in all 10 consuming apps (7 active + 3 currently-disabled: litellm, harbor, home-assistant — required for Helm's dependency version check even though they're inactive).

`identity/keycloakdb-cnpg`'s separate PVC-full incident (also surfaced by this investigation) was already fixed live and merged in `08c63ace`.

Also updates `.plans/TODO.md` to check off the completed items and drops the "delete orphaned backup prefixes" item (kept intentionally — those apps may be re-enabled and restored from those backups later).

## Test plan

- [x] `helm template` rendered for all 7 active apps (bookorbit, gitea, honcho, keycloak, nextcloud/app, nextcloud/onlyoffice, and the `pgsql-cnpg` chart standalone with coder's exact values) — confirmed `archive_timeout: 30min`, `data.compression`/`wal.compression: gzip`, `instanceSidecarConfiguration`, and coder's corrected 6-field schedule all render correctly
- [x] `helm template` also confirmed for the 3 inactive apps (litellm, harbor, home-assistant) to verify the chart defaults propagate without needing per-app config
- [x] `yamllint`/`prettier` clean on all touched files (no new warnings vs. baseline)
- [ ] Post-merge: confirm ArgoCD syncs cleanly and spot-check a couple of live clusters (`archive_timeout`, `ObjectStore` compression) match expectations
- [ ] Re-audit actual S3 usage in a few days to confirm the bloat trend reverses