### PR TITLE
feat(prometheus-stack): CNPG archiving/backup alerts + Discord notifications

### DIFF
--- a/.plans/TODO.md
+++ b/.plans/TODO.md
@@ -11,18 +11,20 @@ General backlog items not tied to a specific migration plan.
 
 ## Infrastructure — Monitoring & Alerting
 
-- [ ] **Alert on CNPG `ContinuousArchivingFailing`**
+- [x] **Alert on CNPG `ContinuousArchivingFailing`** — added `CNPGArchivingStalled` and `CNPGBackupFailing` to a new `PrometheusRule`, based on metric names confirmed live against the cluster (not guessed from docs). Applies to all CNPG clusters via the existing per-cluster PodMonitor labels, not just keycloak. Done via `fbe72147` on branch `feat/cnpg-alerting-notifications`.
   - Surfaced 2026-07-20: `identity/keycloakdb-cnpg` had `ContinuousArchivingFailing` (`barman-cloud-wal-archive: exit status 4`) for ~2 days before its PVC actually filled and the cluster crash-looped
   - Only the generic `KubePersistentVolumeFillingUp` alert caught this, and only once disk was already critical — a last-resort signal, not an early one
   - CNPG pods already expose Prometheus metrics on port 9187 (auto-scraped via per-cluster PodMonitor), but no `PrometheusRule` is built on top of them
   - Add a rule alerting when a `Cluster`'s `ContinuousArchiving` condition is `False` for some sustained window (e.g. 30-60m), and ideally one for failed/incomplete `Backup` CRs too
   - Applies to all CNPG clusters, not just keycloak
 
-- [ ] **Enable Discord + email notifications for Prometheus alerts** — `botkube` is `enabled: "false"` in `cluster/apps/default/botkube/app-config.yaml`, so its half-wired Discord integration (a `prometheus` source plugin exists in `values.yaml` but was never bound to the channel's `sources` list) isn't even running
+- [x] **Enable Discord + email notifications for Prometheus alerts** — configured Alertmanager with a Discord webhook receiver/route for `critical`/`warning` alerts (`@here` on critical), webhook URL delivered via a dedicated `ExternalSecret` + `webhook_url_file` rather than a `<secret:...>` token (the token-substitution path is broken for this chart's Secret shape — see design doc). Email/SMTP receiver and botkube re-enablement deferred, not part of this pass. Done via `84994974` + `c850c1f5` on branch `feat/cnpg-alerting-notifications`.
   - Alertmanager itself has zero receivers configured (`cluster/apps/system/prometheus-stack/values.yaml` only sets `global.resolve_timeout`) — alerts fire and sit with nowhere to go
   - Surfaced 2026-07-20: the `KubePersistentVolumeFillingUp` critical alert fired correctly for `identity/keycloakdb-cnpg` ~6h before the outage was noticed, but nobody was notified — QNAP's own out-of-band alert was the first signal
   - Configure Alertmanager receivers/routes directly: a Discord webhook receiver, plus an email/SMTP receiver, at minimum for `severity: critical`
   - Decide whether to also re-enable botkube (and bind its `prometheus` source) as a second channel, or keep notification ownership solely in Alertmanager to avoid duplicate/half-wired paths
+
+- [ ] **Investigate CNPG archiving/backup anomalies found while building the new alerts (2026-07-20)** — `bookorbdb-cnpg` (bookorbit) has failed every scheduled backup for 5+ consecutive days (`rpc error: code = Unknown desc = exit status 1`); `giteadb-cnpg` (gitea) has gone ~21 days without a successful WAL archive despite `archive_timeout: 30min` being live, while CNPG's own `ContinuousArchiving` condition still reports `True` — could be a genuinely idle database (low `archived_count` supports this) or a real stall the condition isn't catching. The new `CNPGArchivingStalled`/`CNPGBackupFailing` alerts (this PR) will fire on both immediately on merge — expected, not a bug.
 
 ## Infrastructure — CNPG Backup Storage (QNAP S3 bloat)
 

--- a/cluster/apps/system/prometheus-stack/templates/alertmanager-discord-webhook-externalsecret.yaml
+++ b/cluster/apps/system/prometheus-stack/templates/alertmanager-discord-webhook-externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-discord-webhook
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  refreshInterval: 1h
+  target:
+    name: alertmanager-discord-webhook
+    creationPolicy: Owner
+  data:
+    - secretKey: url
+      remoteRef:
+        key: "9ac66262-5201-41cd-a8a6-b48d00e3cb06" #gitleaks:allow #ALERTMANAGER_DISCORD_WEBHOOK

--- a/cluster/apps/system/prometheus-stack/templates/prometheusrule-cnpg.yaml
+++ b/cluster/apps/system/prometheus-stack/templates/prometheusrule-cnpg.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cnpg-alerts
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    release: prometheus-stack
+spec:
+  groups:
+    - name: cnpg.archiving
+      interval: 5m
+      rules:
+        - alert: CNPGArchivingStalled
+          expr: max by (namespace, job) (cnpg_pg_stat_archiver_seconds_since_last_archival) > 3600
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'CNPG WAL archiving stalled on {{`{{ $labels.namespace }}`}}'
+            description: 'No successful WAL archive in {{`{{ $labels.namespace }}`}} for over 1h ({{`{{ $value }}`}}s) — check barman-cloud-wal-archive logs.'
+        - alert: CNPGArchivingStalled
+          expr: max by (namespace, job) (cnpg_pg_stat_archiver_seconds_since_last_archival) > 21600
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: 'CNPG WAL archiving critically stalled on {{`{{ $labels.namespace }}`}}'
+            description: 'No successful WAL archive in {{`{{ $labels.namespace }}`}} for over 6h ({{`{{ $value }}`}}s) — PVC will eventually fill. Check barman-cloud-wal-archive logs.'
+    - name: cnpg.backups
+      interval: 5m
+      rules:
+        - alert: CNPGBackupFailing
+          expr: max by (namespace, job) (cnpg_collector_last_failed_backup_timestamp) > max by (namespace, job) (cnpg_collector_last_available_backup_timestamp)
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'CNPG backups failing on {{`{{ $labels.namespace }}`}}'
+            description: 'The most recent backup attempt in {{`{{ $labels.namespace }}`}} failed and is more recent than the last successful backup.'

--- a/cluster/apps/system/prometheus-stack/values.yaml
+++ b/cluster/apps/system/prometheus-stack/values.yaml
@@ -138,7 +138,22 @@ kube-prometheus-stack:
     config:
       global:
         resolve_timeout: 5m
+      route:
+        routes:
+          - matchers: ['severity=~"critical|warning"']
+            receiver: discord
+            group_by: ['namespace', 'severity']
+      receivers:
+        - name: "null"
+        - name: discord
+          discord_configs:
+            - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord-webhook/url
+              title: '{{ .CommonAnnotations.summary }}'
+              message: |
+                {{ if eq .CommonLabels.severity "critical" }}@here {{ end }}{{ .CommonAnnotations.description }}
     alertmanagerSpec:
+      secrets:
+        - alertmanager-discord-webhook
       storage:
         volumeClaimTemplate:
           spec:

--- a/cluster/apps/system/prometheus-stack/values.yaml
+++ b/cluster/apps/system/prometheus-stack/values.yaml
@@ -144,6 +144,12 @@ kube-prometheus-stack:
             receiver: discord
             group_by: ['namespace', 'severity']
       receivers:
+        # kube-prometheus-stack's default route.receiver is "null" (its scalar
+        # value survives our merge), but Helm replaces list fields wholesale —
+        # without this entry, the receivers list above would silently drop the
+        # default "null" receiver, leaving that reference dangling and making
+        # Alertmanager reject the whole config on load. Keep this even though
+        # nothing here appears to reference it directly.
         - name: "null"
         - name: discord
           discord_configs:

--- a/docs/superpowers/plans/2026-07-20-cnpg-alerting.md
+++ b/docs/superpowers/plans/2026-07-20-cnpg-alerting.md
@@ -1,0 +1,339 @@
+# CNPG Alerting + Alertmanager Notifications Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two CNPG Prometheus alerts (stalled WAL archiving, failing backups) and wire Alertmanager to actually deliver `critical`/`warning` alerts to Discord, so failures like the keycloak PVC-fill incident and the bookorbdb backup-failure streak get noticed within the hour instead of days later.
+
+**Architecture:** A new hand-written `PrometheusRule` in `cluster/apps/system/prometheus-stack/templates/` (same pattern as the existing `prometheusrule-smart.yaml`) adds the two CNPG alerts. `alertmanager.config` in the same app's `values.yaml` gains a `discord` receiver and a route matching `severity=~"critical|warning"`. The webhook URL is kept out of `values.yaml` entirely — it's delivered via a new `ExternalSecret` → `Secret` → `alertmanagerSpec.secrets` mount → `webhook_url_file`, avoiding a confirmed-broken alternative (a `<secret:...>` token would get trapped inside a base64-encoded Secret field that the `argocd-secret-replacer` plugin's literal-text substitution can never reach).
+
+**Tech Stack:** Helm (kube-prometheus-stack 87.5.1 / Alertmanager v0.33.1), Prometheus Operator `PrometheusRule` CRD, External Secrets Operator (`ClusterSecretStore bitwarden`), Bitwarden Secrets Manager (`bws` CLI), ArgoCD GitOps sync.
+
+## Global Constraints
+
+- Design source of truth: `docs/superpowers/specs/2026-07-20-cnpg-alerting-design.md` — read it if anything here is ambiguous.
+- Metric names (`cnpg_pg_stat_archiver_seconds_since_last_archival`, `cnpg_collector_last_failed_backup_timestamp`, `cnpg_collector_last_available_backup_timestamp`) were confirmed live against the cluster's Prometheus — do not substitute different metric names without re-verifying against `curl http://localhost:9090/api/v1/label/__name__/values` (see `prometheus-portforward-session` skill for the port-forward lifecycle across Bash calls).
+- `PrometheusRule` files in this repo use Helm raw-string escaping for Go template syntax, e.g. `{{`{{ $labels.namespace }}`}}` — because they live under `templates/` and are themselves passed through Helm rendering. Copy this pattern exactly; unescaped `{{ }}` will break the Helm render.
+- `alertmanager.config.receivers[].discord_configs[].webhook_url` must **never** be set directly with a `<secret:...>` token — use `webhook_url_file` + `alertmanagerSpec.secrets` as designed. See design doc section 2 for why.
+- Never commit the real Discord webhook URL to git.
+- Branch: `feat/cnpg-alerting-notifications` (already created, design doc already committed on it — do not create a new branch).
+- Kubeconfig for any live cluster checks: `talosctl --talosconfig=/workspaces/home-ops/provision/talos/clusterconfig/talosconfig kubeconfig --nodes 192.168.48.2 --force $KUBECONFIG`.
+
+---
+
+## Task 1: CNPG PrometheusRule
+
+**Files:**
+- Create: `cluster/apps/system/prometheus-stack/templates/prometheusrule-cnpg.yaml`
+
+**Interfaces:**
+- Produces: two Prometheus alert names, `CNPGArchivingStalled` (fires at `severity: warning` and separately at `severity: critical`) and `CNPGBackupFailing` (`severity: warning`). Task 3's Alertmanager route matches on `severity=~"critical|warning"`, so both alert names route to Discord automatically — no additional wiring needed between this task and Task 3.
+
+- [ ] **Step 1: Write the PrometheusRule file**
+
+```yaml
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cnpg-alerts
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    release: prometheus-stack
+spec:
+  groups:
+    - name: cnpg.archiving
+      interval: 5m
+      rules:
+        - alert: CNPGArchivingStalled
+          expr: max by (namespace, job) (cnpg_pg_stat_archiver_seconds_since_last_archival) > 3600
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'CNPG WAL archiving stalled on {{`{{ $labels.namespace }}`}}'
+            description: 'No successful WAL archive in {{`{{ $labels.namespace }}`}} for over 1h ({{`{{ $value }}`}}s) — check barman-cloud-wal-archive logs.'
+        - alert: CNPGArchivingStalled
+          expr: max by (namespace, job) (cnpg_pg_stat_archiver_seconds_since_last_archival) > 21600
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: 'CNPG WAL archiving critically stalled on {{`{{ $labels.namespace }}`}}'
+            description: 'No successful WAL archive in {{`{{ $labels.namespace }}`}} for over 6h ({{`{{ $value }}`}}s) — PVC will eventually fill. Check barman-cloud-wal-archive logs.'
+    - name: cnpg.backups
+      interval: 5m
+      rules:
+        - alert: CNPGBackupFailing
+          expr: max by (namespace, job) (cnpg_collector_last_failed_backup_timestamp) > max by (namespace, job) (cnpg_collector_last_available_backup_timestamp)
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'CNPG backups failing on {{`{{ $labels.namespace }}`}}'
+            description: 'The most recent backup attempt in {{`{{ $labels.namespace }}`}} failed and is more recent than the last successful backup.'
+```
+
+- [ ] **Step 2: Render and verify the rule appears correctly**
+
+```sh
+cd cluster/apps/system/prometheus-stack
+helm template prometheus-stack . -f values.yaml | grep -A3 "name: cnpg-alerts"
+```
+
+Expected: a `PrometheusRule` block with `metadata.name: cnpg-alerts`, `namespace: monitoring`, and the `release: prometheus-stack` label. If nothing prints, the file wasn't picked up by Helm — check it's directly under `templates/` (not a subdirectory) and has valid YAML (`---` document start, correct indentation).
+
+- [ ] **Step 3: Validate the two PromQL expressions against live Prometheus**
+
+```sh
+export KUBECONFIG=/tmp/claude-1000/-workspaces-home-ops/84d4501d-bf31-4bdf-a18f-169a226d4976/scratchpad/kubeconfig
+nohup kubectl -n monitoring port-forward svc/prometheus-stack-kube-prom-prometheus 9090:9090 > /tmp/claude-1000/-workspaces-home-ops/84d4501d-bf31-4bdf-a18f-169a226d4976/scratchpad/pf.log 2>&1 &
+disown
+sleep 3
+curl -s "http://localhost:9090/api/v1/query" --data-urlencode "query=max by (namespace, job) (cnpg_pg_stat_archiver_seconds_since_last_archival) > 3600"
+curl -s "http://localhost:9090/api/v1/query" --data-urlencode "query=max by (namespace, job) (cnpg_collector_last_failed_backup_timestamp) > max by (namespace, job) (cnpg_collector_last_available_backup_timestamp)"
+pkill -f "port-forward.*prometheus"; true
+```
+
+Expected: both return `"status": "success"` (HTTP 200, no PromQL parse error). At time of design, the first query matched `gitea` and `bookorbit` (long-stalled archiving — real, pre-existing conditions, not a bug in the rule) and the second matched `bookorbit` (confirmed failing backup streak). If the scratchpad path above no longer exists (new session), substitute any writable path and regenerate the kubeconfig first via the Global Constraints command.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add cluster/apps/system/prometheus-stack/templates/prometheusrule-cnpg.yaml
+git commit -m "feat(prometheus-stack): add CNPG archiving/backup PrometheusRule"
+```
+
+---
+
+## Task 2: Discord webhook secret
+
+**Files:**
+- Create: `cluster/apps/system/prometheus-stack/templates/alertmanager-discord-webhook-externalsecret.yaml`
+
+**Interfaces:**
+- Consumes: a Discord webhook URL (obtained from the user in Step 1 of this task — cannot be generated programmatically, requires Discord channel UI access).
+- Produces: a K8s `Secret` named `alertmanager-discord-webhook` in the `monitoring` namespace with key `url`, which Task 3's `alertmanagerSpec.secrets: [alertmanager-discord-webhook]` mounts at `/etc/alertmanager/secrets/alertmanager-discord-webhook/url`.
+
+- [ ] **Step 1: Get the Discord webhook URL from the user**
+
+This cannot be automated — stop and ask the user to create a webhook in their target Discord channel (Discord: Channel Settings → Integrations → Webhooks → New Webhook → Copy Webhook URL) and paste the URL. Do not proceed until you have it. Do not echo the full URL back in any commit message, PR description, or log that gets persisted to a shared/visible location.
+
+- [ ] **Step 2: Store it in Bitwarden Secrets Manager**
+
+```sh
+bws secret create ALERTMANAGER_DISCORD_WEBHOOK '<the webhook URL from Step 1>' 422f340a-6eb8-4a4f-90d1-b3fe00d00d76 -o json
+```
+
+Expected: JSON output including an `"id"` field (a UUID) — this is the new secret's ID, needed in Step 3. `422f340a-6eb8-4a4f-90d1-b3fe00d00d76` is the `cluster` Bitwarden project (confirmed via `bws project list` — same project that holds `discord_botid`/`discord_token`/etc.). Do not print or log the webhook URL itself again after this step; only the returned `id` is needed going forward.
+
+- [ ] **Step 3: Write the ExternalSecret**
+
+Replace `<SECRET_ID_FROM_STEP_2>` with the real UUID from Step 2's output:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-discord-webhook
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  refreshInterval: 1h
+  target:
+    name: alertmanager-discord-webhook
+    creationPolicy: Owner
+  data:
+    - secretKey: url
+      remoteRef:
+        key: "<SECRET_ID_FROM_STEP_2>" #gitleaks:allow #ALERTMANAGER_DISCORD_WEBHOOK
+```
+
+No `metadata.namespace` field — matches the existing `harbor-oidc-secret`/`headlamp-oidc` `ExternalSecret`s in this repo, which rely on the ArgoCD Application's destination namespace (`monitoring` here, set in `app-config.yaml`).
+
+- [ ] **Step 4: Render and verify**
+
+```sh
+cd cluster/apps/system/prometheus-stack
+helm template prometheus-stack . -f values.yaml | grep -A12 "name: alertmanager-discord-webhook"
+```
+
+Expected: an `ExternalSecret` block with `secretStoreRef.name: bitwarden`, `target.name: alertmanager-discord-webhook`, and a `data[0].remoteRef.key` containing the real UUID (not the placeholder text) — confirming the substitution in Step 3 was actually made.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add cluster/apps/system/prometheus-stack/templates/alertmanager-discord-webhook-externalsecret.yaml
+git commit -m "feat(prometheus-stack): add ExternalSecret for Alertmanager Discord webhook"
+```
+
+The secret UUID in this commit is a Bitwarden item reference, not the credential itself — safe to commit (matches every other `remoteRef.key` in the repo). Gitleaks will still scan it; the `#gitleaks:allow` comment suppresses any false-positive UUID-looks-like-a-secret flag, matching existing entries.
+
+---
+
+## Task 3: Alertmanager receiver + route
+
+**Files:**
+- Modify: `cluster/apps/system/prometheus-stack/values.yaml` (the `alertmanager:` block, currently only `config.global.resolve_timeout` and `alertmanagerSpec.storage`)
+
+**Interfaces:**
+- Consumes: `alertmanager-discord-webhook` Secret from Task 2 (must exist for `alertmanagerSpec.secrets` to mount successfully at deploy time — safe to write this task's YAML before Task 2's PR merges, since both land in the same PR).
+- Consumes: alert names `CNPGArchivingStalled`, `CNPGBackupFailing` from Task 1 only implicitly (via the `severity` label they set, not by name — this task's route has no CNPG-specific logic, it's generic severity-based routing that also covers the existing `smart-disk-health` alerts).
+
+- [ ] **Step 1: Edit `values.yaml`**
+
+Find the existing `alertmanager:` block:
+
+```yaml
+  alertmanager:
+    config:
+      global:
+        resolve_timeout: 5m
+    alertmanagerSpec:
+      storage:
+        volumeClaimTemplate:
+          spec:
+            accessModes: ["ReadWriteOnce"]
+            resources:
+              requests:
+                storage: 25Gi
+```
+
+Replace it with:
+
+```yaml
+  alertmanager:
+    config:
+      global:
+        resolve_timeout: 5m
+      route:
+        routes:
+          - matchers: ['severity=~"critical|warning"']
+            receiver: discord
+      receivers:
+        - name: discord
+          discord_configs:
+            - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord-webhook/url
+              title: '{{ .CommonAnnotations.summary }}'
+              message: |
+                {{ if eq .CommonLabels.severity "critical" }}@here {{ end }}{{ .CommonAnnotations.description }}
+    alertmanagerSpec:
+      secrets:
+        - alertmanager-discord-webhook
+      storage:
+        volumeClaimTemplate:
+          spec:
+            accessModes: ["ReadWriteOnce"]
+            resources:
+              requests:
+                storage: 25Gi
+```
+
+Note: the `discord_configs` template fields (`title`, `message`) use unescaped `{{ }}` deliberately — this block lives inside a YAML **string value** passed through to Alertmanager's own Go templating at alert-render time, not through Helm's templating (Helm only templates `.yaml`/`.tpl` files under `templates/`, and `values.yaml` is not one — its contents are passed through as literal data). Do not add the triple-backtick raw-string escaping used in `prometheusrule-cnpg.yaml`; that pattern is specific to files under `templates/`.
+
+- [ ] **Step 2: Render and verify the discord receiver + secrets mount**
+
+```sh
+cd cluster/apps/system/prometheus-stack
+helm template prometheus-stack . -f values.yaml > /tmp/claude-1000/-workspaces-home-ops/84d4501d-bf31-4bdf-a18f-169a226d4976/scratchpad/rendered.yaml
+grep -A3 "secrets:" /tmp/claude-1000/-workspaces-home-ops/84d4501d-bf31-4bdf-a18f-169a226d4976/scratchpad/rendered.yaml | grep -A2 "alertmanager-discord-webhook"
+python3 -c "
+import re, base64
+t = open('/tmp/claude-1000/-workspaces-home-ops/84d4501d-bf31-4bdf-a18f-169a226d4976/scratchpad/rendered.yaml').read()
+m = re.search(r'alertmanager\.yaml: \"([^\"]+)\"', t)
+print(base64.b64decode(m.group(1)).decode())
+"
+```
+
+Expected: the first command shows `alertmanager-discord-webhook` under the Alertmanager CR's `spec.secrets`. The decoded config (second command) shows a `discord_configs` receiver with `webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord-webhook/url` (not a literal webhook URL, not a `<secret:...>` token) and a `route.routes` entry matching `severity=~"critical|warning"` → `receiver: discord`.
+
+- [ ] **Step 3: `task lint:all`**
+
+```sh
+task lint:all
+```
+
+Expected: passes (yamllint, helmlint, prettier). Fix any reported formatting issues (typically indentation or trailing whitespace) before continuing.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add cluster/apps/system/prometheus-stack/values.yaml
+git commit -m "feat(prometheus-stack): route critical/warning alerts to Discord"
+```
+
+---
+
+## Task 4: TODO.md update and PR
+
+**Files:**
+- Modify: `.plans/TODO.md`
+
+**Interfaces:** none (documentation-only task).
+
+- [ ] **Step 1: Check off both completed items and add the deferred-investigation note**
+
+In `.plans/TODO.md` under `## Infrastructure — Monitoring & Alerting`, change both `- [ ]` items to `- [x]` and append a short note to each about what was actually implemented (mirroring the style already used for the completed CNPG/backup-storage items above them). Also add a new item noting the two live findings surfaced during this work, for separate follow-up:
+
+```markdown
+- [ ] **Investigate CNPG archiving/backup anomalies found while building the new alerts (2026-07-20)** — `bookorbdb-cnpg` (bookorbit) has failed every scheduled backup for 5+ consecutive days (`rpc error: code = Unknown desc = exit status 1`); `giteadb-cnpg` (gitea) has gone ~21 days without a successful WAL archive despite `archive_timeout: 30min` being live, while CNPG's own `ContinuousArchiving` condition still reports `True` — could be a genuinely idle database (low `archived_count` supports this) or a real stall the condition isn't catching. The new `CNPGArchivingStalled`/`CNPGBackupFailing` alerts (this PR) will fire on both immediately on merge — expected, not a bug.
+```
+
+- [ ] **Step 2: Push and open the PR**
+
+```sh
+git push -u origin feat/cnpg-alerting-notifications
+gh pr create --title "feat(prometheus-stack): CNPG archiving/backup alerts + Discord notifications" --body "$(cat <<'EOF'
+## Summary
+- Add `CNPGArchivingStalled` and `CNPGBackupFailing` PrometheusRule alerts, based on metric names confirmed live against the cluster (not guessed from docs)
+- Configure Alertmanager to route `critical`/`warning` alerts to a Discord webhook, with `@here` on critical
+- Webhook URL delivered via ExternalSecret + `webhook_url_file`, not a `<secret:...>` token (confirmed the token-substitution path is broken for this specific chart's Secret shape — see design doc)
+
+Design: `docs/superpowers/specs/2026-07-20-cnpg-alerting-design.md`
+Plan: `docs/superpowers/plans/2026-07-20-cnpg-alerting.md`
+
+## Test plan
+- [x] `helm template` verified for all three new/changed files
+- [x] Both new PromQL expressions validated against live Prometheus (see Task 1 Step 3)
+- [x] `task lint:all` passes
+- [ ] Post-merge: fire a synthetic test alert via `amtool` and confirm it lands in Discord (see plan's Post-Merge Verification section — requires user go-ahead, not done as part of this PR)
+
+## Note
+Merging this will immediately fire `critical` Discord alerts for `bookorbit` and `gitea` — both are real, pre-existing conditions (see TODO.md follow-up item added in this PR), not false positives from the new rule.
+EOF
+)"
+```
+
+---
+
+## Post-Merge Verification (manual — do not run without explicit user go-ahead)
+
+This step sends a real message to the configured Discord channel and depends on ArgoCD having already synced the merged PR (automatic — `prometheus-stack`'s `app-config.yaml` has `syncPolicy.selfHeal: true`). Do not run it as part of the PR; run it afterward, and only after confirming with the user, since it both touches the live cluster and posts a visible Discord message.
+
+- [ ] **Confirm the Secret synced and Alertmanager picked it up**
+
+```sh
+export KUBECONFIG=/tmp/claude-1000/-workspaces-home-ops/84d4501d-bf31-4bdf-a18f-169a226d4976/scratchpad/kubeconfig
+kubectl get secret -n monitoring alertmanager-discord-webhook
+kubectl get pods -n monitoring -l app.kubernetes.io/name=alertmanager
+```
+
+Expected: the Secret exists, and the Alertmanager pod (`alertmanager-prometheus-stack-kube-prom-alertmanager-0`) is `2/2 Running` with no recent restarts (a bad config causes a crash loop on the `alertmanager` container specifically).
+
+- [ ] **Fire a synthetic test alert**
+
+```sh
+kubectl exec -n monitoring alertmanager-prometheus-stack-kube-prom-alertmanager-0 -c alertmanager -- \
+  amtool alert add alertname="TestAlert" severity="warning" --annotation=summary="Test alert from CNPG alerting rollout" --alertmanager.url=http://localhost:9093
+```
+
+Expected: within ~30s (the configured `group_wait`), a message reading "Test alert from CNPG alerting rollout" appears in the target Discord channel. If nothing arrives, check `kubectl logs -n monitoring alertmanager-prometheus-stack-kube-prom-alertmanager-0 -c alertmanager` for delivery errors (most likely cause: webhook URL was mistyped in Task 2 Step 1, or the Discord webhook was deleted/regenerated since).
+
+- [ ] **Confirm the CNPG alerts are actually active**
+
+```sh
+curl -s "http://localhost:9090/api/v1/query" --data-urlencode 'query=ALERTS{alertname=~"CNPGArchivingStalled|CNPGBackupFailing"}' | python3 -m json.tool
+```
+
+(Requires the Prometheus port-forward from Task 1 Step 3 — restart it if closed.) Expected: entries for `bookorbit` and `gitea` per the known pre-existing conditions (see Task 4's TODO.md note) — confirms the rule is loaded and evaluating, not just rendered.

--- a/docs/superpowers/specs/2026-07-20-cnpg-alerting-design.md
+++ b/docs/superpowers/specs/2026-07-20-cnpg-alerting-design.md
@@ -1,0 +1,186 @@
+# CNPG Alerting + Alertmanager Notifications — Design
+
+## Context
+
+Two related backlog items from `.plans/TODO.md` under "Infrastructure — Monitoring & Alerting":
+
+1. **No alert on CNPG `ContinuousArchivingFailing`.** Surfaced 2026-07-20:
+   `identity/keycloakdb-cnpg` had continuous archiving failing
+   (`barman-cloud-wal-archive: exit status 4`) for ~2 days before its PVC
+   actually filled and the cluster crash-looped. Only the generic
+   `KubePersistentVolumeFillingUp` alert caught it, and only once disk was
+   already critical.
+2. **Alertmanager has zero receivers configured.** `KubePersistentVolumeFillingUp`
+   fired correctly ~6h before the keycloak outage was noticed, but nobody was
+   notified — a QNAP out-of-band alert was the first signal. `botkube` is
+   `enabled: "false"` with a half-wired Discord `prometheus` source that was
+   never bound to the channel.
+
+These are combined into one design because a CNPG-specific alert is useless
+without somewhere for it to go.
+
+**Additional finding during design (2026-07-20):** live Prometheus query
+confirmed `bookorbdb-cnpg` has failed every scheduled backup for at least 5
+consecutive days (2026-07-16 through today, `rpc error: code = Unknown desc =
+exit status 1`), currently undetected. This validates the `CNPGBackupFailing`
+alert design below and is tracked as a separate immediate follow-up, not part
+of this implementation.
+
+## Goals
+
+- Alert early when a CNPG cluster's WAL archiving stalls, before the PVC
+  fills (the keycloak failure mode).
+- Alert when a CNPG cluster's most recent backup attempt failed (the
+  bookorbdb failure mode).
+- Get `critical`/`warning` severity Prometheus alerts routed to a Discord
+  channel, with `@here` on critical, so alerts are actually seen.
+
+## Non-goals
+
+- Email/SMTP receiver — no SMTP relay credentials exist in the cluster; explicitly deferred.
+- Re-enabling `botkube` as a second notification path — Alertmanager owns delivery directly instead, avoiding a second always-on service and a second routing path to maintain.
+- Exposing `Cluster.status.conditions` (e.g. `ContinuousArchiving`) as a metric via kube-state-metrics `customresourcestate` config — not currently configured in this cluster; would be a separate, larger change. The exporter-metric approach below gives an earlier and more precise signal anyway.
+- Investigating/fixing `bookorbdb-cnpg`'s live failing backups — tracked separately.
+
+## Design
+
+### 1. CNPG PrometheusRule
+
+New file: `cluster/apps/system/prometheus-stack/templates/prometheusrule-cnpg.yaml`,
+following the existing hand-written pattern in `templates/prometheusrule-smart.yaml`
+(`monitoring.coreos.com/v1` `PrometheusRule`, labels `app: kube-prometheus-stack`,
+`release: prometheus-stack` so the Prometheus Operator's rule selector picks it up —
+confirmed via `ruleSelectorNilUsesHelmValues: false` in `values.yaml`).
+
+Metric names below were confirmed live against the cluster's Prometheus
+(CNPG's built-in postgres-exporter on port 9187, auto-scraped via per-cluster
+`PodMonitor`) — not guessed from CNPG docs.
+
+**`CNPGArchivingStalled`**
+
+```yaml
+- alert: CNPGArchivingStalled
+  expr: max by (namespace, job) (cnpg_pg_stat_archiver_seconds_since_last_archival) > 3600
+  for: 10m
+  labels:
+    severity: warning
+  annotations:
+    summary: 'CNPG WAL archiving stalled on {{ $labels.namespace }}'
+    description: 'No successful WAL archive in {{ $labels.namespace }} for over 1h — check barman-cloud-wal-archive logs.'
+- alert: CNPGArchivingStalled
+  expr: max by (namespace, job) (cnpg_pg_stat_archiver_seconds_since_last_archival) > 21600
+  for: 10m
+  labels:
+    severity: critical
+  annotations:
+    summary: 'CNPG WAL archiving critically stalled on {{ $labels.namespace }}'
+    description: 'No successful WAL archive in {{ $labels.namespace }} for over 6h — PVC will eventually fill. Check barman-cloud-wal-archive logs.'
+```
+
+- `cnpg_pg_stat_archiver_seconds_since_last_archival` is only meaningfully
+  reported by the primary instance (standbys report `0`/stale); `max by
+  (namespace, job)` collapses to one series per cluster (`job` label is
+  `<namespace>/<cluster>-cnpg`, shared across both instances' pods).
+- Chart-wide `postgresql.parameters.archive_timeout` is `30min`
+  (`charts/pgsql-cnpg/values.yaml`), so this metric cycles up to ~1800s under
+  normal idle operation. Thresholds are set well above that (1h warning, 6h
+  critical) specifically to avoid flapping on that idle cycle.
+- The keycloak incident ran ~2 days before the PVC actually filled, so even
+  the 6h critical threshold is an early, high-confidence signal with no
+  observed false-positive risk against current live data (all six clusters
+  queried sit well under 1h as of this writing, except keycloak itself which
+  is now `-1`/reset after the recent fix).
+
+**`CNPGBackupFailing`**
+
+```yaml
+- alert: CNPGBackupFailing
+  expr: max by (namespace, job) (cnpg_collector_last_failed_backup_timestamp) > max by (namespace, job) (cnpg_collector_last_available_backup_timestamp)
+  for: 30m
+  labels:
+    severity: warning
+  annotations:
+    summary: 'CNPG backups failing on {{ $labels.namespace }}'
+    description: 'The most recent backup attempt in {{ $labels.namespace }} failed and is more recent than the last successful backup.'
+```
+
+- Fires when the most recent backup *attempt* is a failure newer than the
+  last success, and stays firing until a success occurs — correct semantics
+  for "backups are currently in a failing streak," not just "a failure
+  happened once."
+- Confirmed against live data: `bookorbdb-cnpg` currently satisfies this
+  expression (5 consecutive daily `failed` backups, `last_available_backup_timestamp
+  = 0`, i.e. no success ever recorded).
+- `for: 30m` avoids alerting on a single transient failure that's
+  immediately retried; once true, the condition persists until the next
+  scheduled backup succeeds (typically ~24h), so this isn't a
+  window that risks missing the signal.
+
+### 2. Alertmanager Discord receiver + route
+
+Added to `alertmanager.config` in `cluster/apps/system/prometheus-stack/values.yaml`
+(currently only sets `global.resolve_timeout`):
+
+```yaml
+alertmanager:
+  config:
+    global:
+      resolve_timeout: 5m
+    route:
+      routes:
+        - matchers: ['severity=~"critical|warning"']
+          receiver: discord
+    receivers:
+      - name: discord
+        discord_configs:
+          - webhook_url: <secret:discord_alertmanager_webhook>
+            title: '{{ .CommonAnnotations.summary }}'
+            message: |
+              {{ if eq .CommonLabels.severity "critical" }}@here {{ end }}{{ .CommonAnnotations.description }}
+```
+
+- `critical` and `warning` both route to Discord (per decision below);
+  `@here` mention is added only for `critical` via the message template
+  conditional — no extra secret/role-ID plumbing needed.
+- New Discord **channel webhook** (Discord's native webhook mechanism,
+  distinct from botkube's bot-token/bot-ID integration — a new webhook must
+  be created in the target Discord channel's settings).
+- New Bitwarden secret `discord_alertmanager_webhook`, added as an entry in
+  `cluster/apps/core/argocd/resources/cluster-secrets-externalsecret.yaml`
+  (same list as the existing `discord_botid`/`discord_token`/`discord_channel`
+  entries) and substituted via the `cluster-secrets` mount + `<secret:...>`
+  token, matching the established pattern already used for botkube's
+  Discord credentials.
+  - Rationale for `cluster-secrets` over a per-app `ExternalSecret`: kube-prometheus-stack's
+    `alertmanager.config` values.yaml block is transformed by the chart into
+    a Secret internally as a single opaque blob — there's no clean way to
+    inject one field of it from a separately-managed K8s `Secret`. This
+    mirrors why botkube's `discord_botid`/`discord_token` already use
+    `cluster-secrets` substitution rather than a dedicated `ExternalSecret`,
+    despite CLAUDE.md's general rule favoring `ExternalSecret` for
+    `Secret data/stringData` fields.
+- `cluster/apps/system/prometheus-stack/app-config.yaml` needs
+  `SECRET_PROVIDER: cluster-secrets` set (to be confirmed/added during
+  implementation — not currently present).
+
+### 3. Verification plan
+
+- `helm template prometheus-stack . -f values.yaml` before committing, to
+  confirm the rendered `PrometheusRule` and the Alertmanager config Secret
+  both render as expected (no broken Go templating in the Discord message).
+- After deploy, fire a synthetic test alert via `amtool alert add` (through
+  `kubectl exec` into the alertmanager pod, or via a port-forward) to confirm
+  the Discord message actually arrives — not just that the YAML is valid.
+- Spot-check the two new `PrometheusRule` alerts against current live metric
+  values (already done during design — see confirmed values above) to make
+  sure they don't fire immediately on merge for any existing healthy
+  cluster.
+
+## Open follow-ups (not in this implementation)
+
+- Investigate `bookorbdb-cnpg`'s live failing backup streak (separate task).
+- Email/SMTP receiver, if Discord proves insufficient.
+- Re-enable botkube as a second channel, if ever desired.
+- Expose CRD `status.conditions` via kube-state-metrics `customresourcestate`,
+  if a condition-based (rather than metric-based) alert is ever needed for
+  other CRDs too.

--- a/docs/superpowers/specs/2026-07-20-cnpg-alerting-design.md
+++ b/docs/superpowers/specs/2026-07-20-cnpg-alerting-design.md
@@ -118,11 +118,28 @@ Metric names below were confirmed live against the cluster's Prometheus
 
 ### 2. Alertmanager Discord receiver + route
 
+**Correction made during implementation planning (2026-07-20):** the
+original draft of this section used a `<secret:discord_alertmanager_webhook>`
+token directly in `alertmanager.config.receivers[].discord_configs[].webhook_url`,
+following the `cluster-secrets` pattern botkube uses. This was tested against
+a real render and found broken: unlike botkube's chart (which puts secrets in
+a plain `stringData` block), kube-prometheus-stack's `alertmanager.config`
+gets marshalled into **base64-encoded** `data.alertmanager.yaml` inside a
+chart-managed Secret. The `argocd-secret-replacer` CMP plugin does literal
+text substitution on the rendered manifest stream (confirmed via
+`docs/superpowers/plans/2026-07-08-dragonfly-operator.md`'s prior encounter
+with the same plugin missing a `urlquery`-mangled token) — a token trapped
+inside base64 can never match. The corrected design below avoids the problem
+entirely by keeping the webhook URL out of `alertmanager.config` altogether.
+
 Added to `alertmanager.config` in `cluster/apps/system/prometheus-stack/values.yaml`
 (currently only sets `global.resolve_timeout`):
 
 ```yaml
 alertmanager:
+  alertmanagerSpec:
+    secrets:
+      - alertmanager-discord-webhook
   config:
     global:
       resolve_timeout: 5m
@@ -133,7 +150,7 @@ alertmanager:
     receivers:
       - name: discord
         discord_configs:
-          - webhook_url: <secret:discord_alertmanager_webhook>
+          - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord-webhook/url
             title: '{{ .CommonAnnotations.summary }}'
             message: |
               {{ if eq .CommonLabels.severity "critical" }}@here {{ end }}{{ .CommonAnnotations.description }}
@@ -145,23 +162,21 @@ alertmanager:
 - New Discord **channel webhook** (Discord's native webhook mechanism,
   distinct from botkube's bot-token/bot-ID integration — a new webhook must
   be created in the target Discord channel's settings).
-- New Bitwarden secret `discord_alertmanager_webhook`, added as an entry in
-  `cluster/apps/core/argocd/resources/cluster-secrets-externalsecret.yaml`
-  (same list as the existing `discord_botid`/`discord_token`/`discord_channel`
-  entries) and substituted via the `cluster-secrets` mount + `<secret:...>`
-  token, matching the established pattern already used for botkube's
-  Discord credentials.
-  - Rationale for `cluster-secrets` over a per-app `ExternalSecret`: kube-prometheus-stack's
-    `alertmanager.config` values.yaml block is transformed by the chart into
-    a Secret internally as a single opaque blob — there's no clean way to
-    inject one field of it from a separately-managed K8s `Secret`. This
-    mirrors why botkube's `discord_botid`/`discord_token` already use
-    `cluster-secrets` substitution rather than a dedicated `ExternalSecret`,
-    despite CLAUDE.md's general rule favoring `ExternalSecret` for
-    `Secret data/stringData` fields.
-- `cluster/apps/system/prometheus-stack/app-config.yaml` needs
-  `SECRET_PROVIDER: cluster-secrets` set (to be confirmed/added during
-  implementation — not currently present).
+- The webhook URL itself never enters `values.yaml` or any `<secret:...>`
+  token. Instead: a new `ExternalSecret` (`cluster/apps/system/prometheus-stack/templates/alertmanager-discord-webhook-externalsecret.yaml`)
+  pulls a new Bitwarden Secrets Manager item into a plain K8s `Secret` named
+  `alertmanager-discord-webhook` with key `url` — the standard per-app
+  `ExternalSecret` + `ClusterSecretStore bitwarden` mechanism, matching
+  `harbor-oidc-secret`/`headlamp-oidc` precedent, and the mechanism CLAUDE.md
+  already prescribes for tokens that land in `Secret data/stringData`.
+  `alertmanagerSpec.secrets: [alertmanager-discord-webhook]` (Prometheus
+  Operator field, mounts arbitrary named Secrets into the Alertmanager pod at
+  `/etc/alertmanager/secrets/<name>/`) makes that Secret's `url` key
+  available to Alertmanager as a file, which `webhook_url_file` reads.
+- `cluster/apps/system/prometheus-stack/app-config.yaml` already has
+  `SECRET_PROVIDER: cluster-secrets` set — no longer strictly required for
+  this feature since no `<secret:...>` token is used here, but left as-is
+  since other values in the file may still depend on it.
 
 ### 3. Verification plan
 


### PR DESCRIPTION
## Summary
- Add `CNPGArchivingStalled` and `CNPGBackupFailing` PrometheusRule alerts, based on metric names confirmed live against the cluster (not guessed from docs)
- Configure Alertmanager to route `critical`/`warning` alerts to a Discord webhook, with `@here` on critical
- Webhook URL delivered via ExternalSecret + `webhook_url_file`, not a `<secret:...>` token (confirmed the token-substitution path is broken for this specific chart's Secret shape — see design doc)

Design: `docs/superpowers/specs/2026-07-20-cnpg-alerting-design.md`
Plan: `docs/superpowers/plans/2026-07-20-cnpg-alerting.md`

## Test plan
- [x] `helm template` verified for all three new/changed files
- [x] Both new PromQL expressions validated against live Prometheus (see Task 1 Step 3)
- [x] `task lint:all` passes
- [ ] Post-merge: fire a synthetic test alert via `amtool` and confirm it lands in Discord (see plan's Post-Merge Verification section — requires user go-ahead, not done as part of this PR)

## Note
Merging this will immediately fire `critical` Discord alerts for `bookorbit` and `gitea` — both are real, pre-existing conditions (see TODO.md follow-up item added in this PR), not false positives from the new rule.