### PR TITLE
fix(prometheus-stack): fix Alertmanager Discord webhook delivery

### DIFF
--- a/cluster/apps/system/prometheus-stack/templates/alertmanager-discord-webhook-externalsecret.yaml
+++ b/cluster/apps/system/prometheus-stack/templates/alertmanager-discord-webhook-externalsecret.yaml
@@ -1,15 +1,94 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: alertmanager-discord-webhook
+  name: alertmanager-config
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
     name: bitwarden
   refreshInterval: 1h
   target:
-    name: alertmanager-discord-webhook
+    name: alertmanager-config
     creationPolicy: Owner
+    template:
+      data:
+        # This whole config is hand-rolled instead of using the chart's
+        # config values.yaml block, because useExistingSecret true
+        # (values.yaml) makes the chart skip generating its own config
+        # Secret entirely - so this reproduces the chart default
+        # global/inhibit_rules/route verbatim (see kube-prometheus-stack's
+        # own values.yaml) plus our discord receiver. Do not reintroduce
+        # a file-based webhook URL reference here: the Prometheus
+        # Operator's own config parser (not just Alertmanager itself)
+        # rejects that field name in this environment. The plain inline
+        # field needs the real value, and this ExternalSecret's
+        # server-side templating (not a git-committed placeholder token)
+        # is how it gets there without ever landing in git.
+        #
+        # Escaping warning: this block is rendered twice - once by Helm
+        # (this file lives under templates/) and once by External Secrets
+        # Operator's own Go templating (target.template.data values are
+        # templated against this ExternalSecret's resolved data). The
+        # webhook URL substitution is meant for ESO to resolve, so it only
+        # needs Helm's raw-string escape (backtick-wrapped). Everything
+        # meant for Alertmanager's OWN Go templating (title/message) must
+        # survive both stages untouched, so it is escaped twice: once so
+        # ESO prints it literally instead of executing it, and again so
+        # Helm does the same. Do not write literal template delimiter
+        # pairs anywhere in this file outside the three already-escaped
+        # lines below, including in comments - Helm evaluates them even
+        # inside YAML comments, and a stray unescaped pair silently
+        # renders as empty text instead of erroring. Verified against the
+        # live cluster after deploy; a plain render is not sufficient to
+        # catch a break here.
+        alertmanager.yaml: |
+          global:
+            resolve_timeout: 5m
+          inhibit_rules:
+            - source_matchers:
+                - 'severity = critical'
+              target_matchers:
+                - 'severity =~ warning|info'
+              equal:
+                - 'namespace'
+                - 'alertname'
+            - source_matchers:
+                - 'severity = warning'
+              target_matchers:
+                - 'severity = info'
+              equal:
+                - 'namespace'
+                - 'alertname'
+            - source_matchers:
+                - 'alertname = InfoInhibitor'
+              target_matchers:
+                - 'severity = info'
+              equal:
+                - 'namespace'
+            - target_matchers:
+                - 'alertname = InfoInhibitor'
+          route:
+            group_by: ['namespace']
+            group_wait: 30s
+            group_interval: 5m
+            repeat_interval: 12h
+            receiver: 'null'
+            routes:
+              - receiver: 'null'
+                matchers:
+                  - alertname = "Watchdog"
+              - matchers: ['severity=~"critical|warning"']
+                receiver: discord
+                group_by: ['namespace', 'severity']
+          receivers:
+            - name: 'null'
+            - name: discord
+              discord_configs:
+                - webhook_url: {{`{{ .url }}`}}
+                  title: {{`{{ "{{" }} .CommonAnnotations.summary {{ "}}" }}`}}
+                  message: {{`{{ "{{" }} if eq .CommonLabels.severity "critical" {{ "}}" }}@here {{ "{{" }} end {{ "}}" }}{{ "{{" }} .CommonAnnotations.description {{ "}}" }}`}}
+          templates:
+            - /etc/alertmanager/config/*.tmpl
   data:
     - secretKey: url
       remoteRef:

--- a/cluster/apps/system/prometheus-stack/templates/alertmanager-discord-webhook-externalsecret.yaml
+++ b/cluster/apps/system/prometheus-stack/templates/alertmanager-discord-webhook-externalsecret.yaml
@@ -1,107 +1,15 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: alertmanager-config
+  name: alertmanager-discord-webhook
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
     name: bitwarden
   refreshInterval: 1h
   target:
-    name: alertmanager-config
+    name: alertmanager-discord-webhook
     creationPolicy: Owner
-    template:
-      data:
-        # This whole config is hand-rolled instead of using the chart's
-        # config values.yaml block, because useExistingSecret true
-        # (values.yaml) makes the chart skip generating its own config
-        # Secret entirely - so this reproduces the chart default
-        # global/inhibit_rules/route verbatim (see kube-prometheus-stack's
-        # own values.yaml) plus our discord receiver. Do not reintroduce
-        # a file-based webhook URL reference here: the Prometheus
-        # Operator's own config parser (not just Alertmanager itself)
-        # rejects that field name in this environment. The plain inline
-        # field needs the real value, and this ExternalSecret's
-        # server-side templating (not a git-committed placeholder token)
-        # is how it gets there without ever landing in git.
-        #
-        # Upstream tracking: this is a known, still-open Operator bug, not
-        # a quirk of our setup - prometheus-operator/prometheus-operator
-        # issue 7159 ("Missed webhook_url_file option for receivers
-        # discord_config") has the identical error text. A fix exists as
-        # prometheus-operator/prometheus-operator PR 6346 but is unmerged
-        # (changes requested, marked stale as of this writing). Once that
-        # PR merges and ships in the chart's bundled Operator version,
-        # revert this file and values.yaml's alertmanagerSpec back to the
-        # simpler webhook_url_file + alertmanagerSpec.secrets approach
-        # (see git history around this commit for the exact prior form)
-        # and this whole hand-rolled config plus its double-escaping goes
-        # away.
-        #
-        # Escaping warning: this block is rendered twice - once by Helm
-        # (this file lives under templates/) and once by External Secrets
-        # Operator's own Go templating (target.template.data values are
-        # templated against this ExternalSecret's resolved data). The
-        # webhook URL substitution is meant for ESO to resolve, so it only
-        # needs Helm's raw-string escape (backtick-wrapped). Everything
-        # meant for Alertmanager's OWN Go templating (title/message) must
-        # survive both stages untouched, so it is escaped twice: once so
-        # ESO prints it literally instead of executing it, and again so
-        # Helm does the same. Do not write literal template delimiter
-        # pairs anywhere in this file outside the three already-escaped
-        # lines below, including in comments - Helm evaluates them even
-        # inside YAML comments, and a stray unescaped pair silently
-        # renders as empty text instead of erroring. Verified against the
-        # live cluster after deploy; a plain render is not sufficient to
-        # catch a break here.
-        alertmanager.yaml: |
-          global:
-            resolve_timeout: 5m
-          inhibit_rules:
-            - source_matchers:
-                - 'severity = critical'
-              target_matchers:
-                - 'severity =~ warning|info'
-              equal:
-                - 'namespace'
-                - 'alertname'
-            - source_matchers:
-                - 'severity = warning'
-              target_matchers:
-                - 'severity = info'
-              equal:
-                - 'namespace'
-                - 'alertname'
-            - source_matchers:
-                - 'alertname = InfoInhibitor'
-              target_matchers:
-                - 'severity = info'
-              equal:
-                - 'namespace'
-            - target_matchers:
-                - 'alertname = InfoInhibitor'
-          route:
-            group_by: ['namespace']
-            group_wait: 30s
-            group_interval: 5m
-            repeat_interval: 12h
-            receiver: 'null'
-            routes:
-              - receiver: 'null'
-                matchers:
-                  - alertname = "Watchdog"
-              - matchers: ['severity=~"critical|warning"']
-                receiver: discord
-                group_by: ['namespace', 'severity']
-          receivers:
-            - name: 'null'
-            - name: discord
-              discord_configs:
-                - webhook_url: {{`{{ .url }}`}}
-                  title: {{`{{ "{{" }} .CommonAnnotations.summary {{ "}}" }}`}}
-                  message: {{`{{ "{{" }} if eq .CommonLabels.severity "critical" {{ "}}" }}@here {{ "{{" }} end {{ "}}" }}{{ "{{" }} .CommonAnnotations.description {{ "}}" }}`}}
-          templates:
-            - /etc/alertmanager/config/*.tmpl
   data:
     - secretKey: url
       remoteRef:

--- a/cluster/apps/system/prometheus-stack/templates/alertmanager-discord-webhook-externalsecret.yaml
+++ b/cluster/apps/system/prometheus-stack/templates/alertmanager-discord-webhook-externalsecret.yaml
@@ -25,6 +25,19 @@ spec:
         # server-side templating (not a git-committed placeholder token)
         # is how it gets there without ever landing in git.
         #
+        # Upstream tracking: this is a known, still-open Operator bug, not
+        # a quirk of our setup - prometheus-operator/prometheus-operator
+        # issue 7159 ("Missed webhook_url_file option for receivers
+        # discord_config") has the identical error text. A fix exists as
+        # prometheus-operator/prometheus-operator PR 6346 but is unmerged
+        # (changes requested, marked stale as of this writing). Once that
+        # PR merges and ships in the chart's bundled Operator version,
+        # revert this file and values.yaml's alertmanagerSpec back to the
+        # simpler webhook_url_file + alertmanagerSpec.secrets approach
+        # (see git history around this commit for the exact prior form)
+        # and this whole hand-rolled config plus its double-escaping goes
+        # away.
+        #
         # Escaping warning: this block is rendered twice - once by Helm
         # (this file lives under templates/) and once by External Secrets
         # Operator's own Go templating (target.template.data values are

--- a/cluster/apps/system/prometheus-stack/templates/alertmanagerconfig-discord.yaml
+++ b/cluster/apps/system/prometheus-stack/templates/alertmanagerconfig-discord.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: discord
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    release: prometheus-stack
+spec:
+  route:
+    receiver: discord
+    groupBy: ['namespace', 'severity']
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 12h
+    matchers:
+      - name: severity
+        matchType: =~
+        value: 'critical|warning'
+  receivers:
+    - name: discord
+      discordConfigs:
+        - apiURL:
+            name: alertmanager-discord-webhook
+            key: url
+          title: '{{`{{ .CommonAnnotations.summary }}`}}'
+          message: '{{`{{ if eq .CommonLabels.severity "critical" }}@here {{ end }}{{ .CommonAnnotations.description }}`}}'
+          sendResolved: true

--- a/cluster/apps/system/prometheus-stack/values.yaml
+++ b/cluster/apps/system/prometheus-stack/values.yaml
@@ -135,18 +135,28 @@ kube-prometheus-stack:
           url: https://raw.githubusercontent.com/rook/rook/v1.20.0/deploy/examples/monitoring/grafana/Ceph%20Pools%20Dashboard.json
           token: ""
   alertmanager:
-    # No `config:` block here — Alertmanager's config comes from a
-    # self-managed Secret instead (see alertmanagerSpec.useExistingSecret
-    # below and templates/alertmanager-discord-webhook-externalsecret.yaml).
-    # This chart's own config generation would need to embed the real
-    # Discord webhook URL as a `webhook_url_file` reference, which the
-    # Prometheus Operator's config parser in this environment rejects
-    # ("field webhook_url_file not found in type alertmanager.discordConfig")
-    # regardless of where the referenced secret comes from — confirmed live,
-    # not just via `helm template`, which can't catch this class of failure.
+    # No `config:` block here — deliberately left as the chart's own
+    # default (null receiver + Watchdog->null + standard inhibit_rules).
+    # Discord routing is handled entirely by the AlertmanagerConfig CRD
+    # (templates/alertmanagerconfig-discord.yaml) instead of a raw
+    # discord_configs entry in this values.yaml block, because the raw
+    # config path requires a webhook_url_file reference that the
+    # Prometheus Operator's config parser rejects in this environment
+    # ("field webhook_url_file not found in type alertmanager.discordConfig",
+    # confirmed live — prometheus-operator/prometheus-operator#7159, open
+    # upstream, fix unmerged as prometheus-operator/prometheus-operator#6346).
+    # The AlertmanagerConfig CRD's discordConfigs[].apiURL is a native
+    # SecretKeySelector, unaffected by that bug.
     alertmanagerSpec:
-      useExistingSecret: true
-      configSecret: alertmanager-config
+      # AlertmanagerConfig objects default to only matching alerts in their
+      # own namespace (the operator force-injects a namespace matcher on
+      # their first-level route). CNPG alerts span every app namespace, so
+      # routing needs None here to let alertmanagerconfig-discord.yaml's own
+      # severity matcher control matching instead of an implicit namespace
+      # scope. There's only one AlertmanagerConfig object in this cluster,
+      # so there's no multi-tenant isolation being given up by this.
+      alertmanagerConfigMatcherStrategy:
+        type: None
       storage:
         volumeClaimTemplate:
           spec:

--- a/cluster/apps/system/prometheus-stack/values.yaml
+++ b/cluster/apps/system/prometheus-stack/values.yaml
@@ -135,31 +135,18 @@ kube-prometheus-stack:
           url: https://raw.githubusercontent.com/rook/rook/v1.20.0/deploy/examples/monitoring/grafana/Ceph%20Pools%20Dashboard.json
           token: ""
   alertmanager:
-    config:
-      global:
-        resolve_timeout: 5m
-      route:
-        routes:
-          - matchers: ['severity=~"critical|warning"']
-            receiver: discord
-            group_by: ['namespace', 'severity']
-      receivers:
-        # kube-prometheus-stack's default route.receiver is "null" (its scalar
-        # value survives our merge), but Helm replaces list fields wholesale —
-        # without this entry, the receivers list above would silently drop the
-        # default "null" receiver, leaving that reference dangling and making
-        # Alertmanager reject the whole config on load. Keep this even though
-        # nothing here appears to reference it directly.
-        - name: "null"
-        - name: discord
-          discord_configs:
-            - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord-webhook/url
-              title: '{{ .CommonAnnotations.summary }}'
-              message: |
-                {{ if eq .CommonLabels.severity "critical" }}@here {{ end }}{{ .CommonAnnotations.description }}
+    # No `config:` block here — Alertmanager's config comes from a
+    # self-managed Secret instead (see alertmanagerSpec.useExistingSecret
+    # below and templates/alertmanager-discord-webhook-externalsecret.yaml).
+    # This chart's own config generation would need to embed the real
+    # Discord webhook URL as a `webhook_url_file` reference, which the
+    # Prometheus Operator's config parser in this environment rejects
+    # ("field webhook_url_file not found in type alertmanager.discordConfig")
+    # regardless of where the referenced secret comes from — confirmed live,
+    # not just via `helm template`, which can't catch this class of failure.
     alertmanagerSpec:
-      secrets:
-        - alertmanager-discord-webhook
+      useExistingSecret: true
+      configSecret: alertmanager-config
       storage:
         volumeClaimTemplate:
           spec:


### PR DESCRIPTION
## Summary
- The original approach from #4625 (`webhook_url_file` + `alertmanagerSpec.secrets`) never actually worked: the Prometheus Operator's own config parser rejects `webhook_url_file` for `discord_configs` in this environment (`field webhook_url_file not found in type alertmanager.discordConfig`), confirmed live in the operator's logs after merge — Alertmanager silently kept its old, receiver-less config the entire time. This is a known, still-open upstream bug: [prometheus-operator/prometheus-operator#7159](https://github.com/prometheus-operator/prometheus-operator/issues/7159), fix unmerged as [#6346](https://github.com/prometheus-operator/prometheus-operator/pull/6346).
- Switches Discord routing to the Prometheus Operator's native `AlertmanagerConfig` CRD. `discordConfigs[].apiURL` is a plain `SecretKeySelector` — resolved by the operator directly via the Kubernetes API, unaffected by the `webhook_url_file` bug since it's a completely different field on a different resource type. No templating tricks needed for the secret reference at all.
- `title`/`message` only need Helm's own raw-string escaping (same pattern as `prometheusrule-cnpg.yaml`) since `AlertmanagerConfig` fields are plain strings, not routed through any secret templating.
- `alertmanagerConfigMatcherStrategy: None` is required because `AlertmanagerConfig` objects otherwise only match alerts in their own namespace (operator-injected matcher) — our CNPG alerts span every app namespace.
- Restores the chart's own default `alertmanager.config` (null receiver, Watchdog routing, inhibit_rules) instead of hand-maintaining a full copy of it, which an earlier commit on this branch had to do before this simplification.
- Same approach independently used in [wcorn/orino#539](https://github.com/wcorn/orino/pull/539) after hitting the identical operator bug.

## Test plan
- [x] `helm template` verified: `AlertmanagerConfig` renders with correct `apiURL` SecretKeySelector, `title`/`message` render as literal Alertmanager template syntax (not executed by Helm), chart's default null/Watchdog/inhibit_rules config is restored, `alertmanagerConfigMatcherStrategy: None` set on the Alertmanager CR
- [x] `yamllint` passes
- [ ] Post-merge: confirm the Prometheus Operator no longer logs any config errors, confirm `AlertmanagerConfig` status shows `Accepted`, and fire a synthetic test alert to confirm it reaches Discord — can only be verified against the live cluster