### PR TITLE
fix(rook-ceph): scope CephNodeNetworkPacket alerts to node-exporter job

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -25,3 +25,4 @@
 - [Home network hardware](reference_home_network_hardware.md) — router/NAS/RPi IPs and roles
 - [QNAP QuObjects + barman-cloud caveat](reference_qnap_s3_barman_caveat.md) — boto3 ≥1.34 checksum fix required; set AWS_REQUEST_CHECKSUM_CALCULATION=when_required on all CNPG ObjectStores
 - [App removal procedure](reference_app_removal_procedure.md) — deleting the app dir never auto-prunes; manual `kubectl delete application` + separate PVC check required
+- [Ceph alert job scoping gotcha](reference_ceph_alert_job_scoping.md) — Ceph-mixin PrometheusRules lack job filters, can false-positive on non-cluster targets (router); fix via prometheusRuleOverrides

--- a/.claude/memory/reference_ceph_alert_job_scoping.md
+++ b/.claude/memory/reference_ceph_alert_job_scoping.md
@@ -1,0 +1,17 @@
+---
+name: reference-ceph-alert-job-scoping
+description: "Rook-Ceph's bundled Ceph-mixin PrometheusRules have no job filter and can false-positive on unrelated Prometheus targets; fix via prometheusRuleOverrides expr override"
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: ce2af84b-be52-4e48-9b0b-8db6e2d9965d
+  modified: 2026-07-27T10:27:44.622Z
+---
+
+Rook-Ceph's bundled Ceph-mixin alert rules (rendered from `prometheus/localrules.yaml` inside the `rook-ceph-cluster` chart) generally have **no `job` label filter** in their `expr` — they match any series with the right metric name across the whole Prometheus instance, not just real cluster/Ceph nodes.
+
+This caused `CephNodeNetworkPacketErrors`/`CephNodeNetworkPacketDrops` to fire on the `asusrouter` scrape job (router `/metrics` at `192.168.50.1:9101`, see [[reference_home_network_hardware]]) instead of only the k8s nodes' `node-exporter` job — specifically on `eth5`, the router's 2.4GHz WiFi radio (confirmed via router syslog: `hostapd`/`wlceventd`/`acsd` log lines on that interface), not a wired NIC. The errors were normal 802.11 retry counters from a roaming client with weak signal — cosmetic, unrelated to cluster/storage health.
+
+**Fix pattern**: `cluster/apps/core/rook-ceph/cluster/values.yaml` already has a `rook-ceph-cluster.monitoring.prometheusRuleOverrides` map (chart template does `mergeOverwrite $rule $ruleOverrides` keyed by alert name — see `templates/prometheusrules.yaml` in the vendored chart). Any rule field, including `expr`, can be overridden there. Fixed by adding `job="node-exporter"` to every `rate()` call in the affected rules' `expr`, matching how the bundled node-exporter mixin already scopes the equivalent alerts. PR: https://github.com/mmalyska/home-ops/pull/4693.
+
+**How to apply**: if a new Discord/Alertmanager alert mentions a node/interface that doesn't match a real cluster node (mc1/mc2/mc3/nv1), check whether it's a Ceph-mixin default rule matching a non-cluster Prometheus target (`asusrouter`, `qnap` jobs) before assuming it's a real hardware/cluster issue. To inspect a rule's live `expr`/annotations, hit `/api/v1/rules` on the port-forwarded Prometheus (see [[prometheus-portforward-session]] skill) rather than guessing from the alert text alone — the default kube-prometheus-stack node-exporter mixin rules ARE properly job-scoped; it's specifically the Ceph-mixin ones that aren't.

--- a/cluster/apps/core/rook-ceph/cluster/values.yaml
+++ b/cluster/apps/core/rook-ceph/cluster/values.yaml
@@ -11,8 +11,15 @@ rook-ceph-cluster:
     createPrometheusRules: true
     rulesNamespaceOverride: monitoring
     prometheusRuleOverrides:
+      # Upstream expr has no job filter, so it also matches non-cluster
+      # node_network_* exporters (e.g. the asusrouter scrape job) and fires
+      # on router WiFi radio interfaces. Scope to job="node-exporter" like
+      # the bundled node-exporter mixin rules already do for the same check.
       CephNodeNetworkPacketDrops:
         for: 5m
+        expr: (rate(node_network_receive_drop_total{device!="lo",job="node-exporter"}[1m]) + rate(node_network_transmit_drop_total{device!="lo",job="node-exporter"}[1m])) / (rate(node_network_receive_packets_total{device!="lo",job="node-exporter"}[1m]) + rate(node_network_transmit_packets_total{device!="lo",job="node-exporter"}[1m])) >= 0.005 and (rate(node_network_receive_drop_total{device!="lo",job="node-exporter"}[1m]) + rate(node_network_transmit_drop_total{device!="lo",job="node-exporter"}[1m])) >= 10
+      CephNodeNetworkPacketErrors:
+        expr: (rate(node_network_receive_errs_total{device!="lo",job="node-exporter"}[1m]) + rate(node_network_transmit_errs_total{device!="lo",job="node-exporter"}[1m])) / (rate(node_network_receive_packets_total{device!="lo",job="node-exporter"}[1m]) + rate(node_network_transmit_packets_total{device!="lo",job="node-exporter"}[1m])) >= 0.0001 or (rate(node_network_receive_errs_total{device!="lo",job="node-exporter"}[1m]) + rate(node_network_transmit_errs_total{device!="lo",job="node-exporter"}[1m])) >= 10
   toolbox:
     enabled: true
   ingress:


### PR DESCRIPTION
## Summary
- Rook-Ceph's bundled `CephNodeNetworkPacketErrors`/`CephNodeNetworkPacketDrops` alert rules have no `job` filter in their upstream `expr`, so they match *any* Prometheus target exposing `node_network_*` metrics — not just real node-exporter cluster nodes.
- The `asusrouter` scrape job (`192.168.50.1:9101`) exposes the same metric shape, so these rules were firing on the router's `eth5` interface — which is its 2.4GHz WiFi radio, not a wired NIC. The errors are normal 802.11 retry counters from a roaming client with marginal signal, unrelated to cluster health.
- Overrides both rules' `expr` (via the existing `prometheusRuleOverrides` mechanism) to add `job="node-exporter"`, matching the scoping the bundled node-exporter mixin already uses for the equivalent checks. Preserves the existing `for: 5m` override on `CephNodeNetworkPacketDrops`.

## Test plan
- [x] Rendered the vendored `rook-ceph-cluster` chart (v1.20.2) locally with this values file and confirmed both rules render with `job="node-exporter"` baked into `expr`, and `for: 5m` is preserved on `CephNodeNetworkPacketDrops`.
- [x] `yamllint -c .github/linters/.yamllint.yaml cluster/apps/core/rook-ceph/cluster/values.yaml` — clean.
- [x] `task lint:all` — no new findings in the changed file (pre-existing warnings elsewhere are unrelated).