### PR TITLE
fix(prometheus-stack): run Grafana datasources sidecar as native init sidecar

### DIFF
--- a/cluster/apps/system/prometheus-stack/values.yaml
+++ b/cluster/apps/system/prometheus-stack/values.yaml
@@ -143,6 +143,21 @@ kube-prometheus-stack:
         access: proxy
         url: http://loki.monitoring.svc.cluster.local:3100
         isDefault: false
+    sidecar:
+      datasources:
+        # Runs the datasources sidecar as a native Kubernetes sidecar
+        # (restartPolicy: Always on an initContainer, K8s 1.29+) so the
+        # ConfigMap-sourced datasources file is fully written before Grafana's
+        # one-shot (non-watching) datasource provisioning scan runs at boot,
+        # while still continuing to watch for future changes afterward.
+        # Without this, a race on cold start can silently drop brand-new
+        # datasources (observed: Loki missing from /api/datasources after
+        # the initial sync, confirmed not self-healing across 3+ minutes).
+        # restartPolicy: Always is required here — without it this becomes a
+        # classic init container running a perpetual WATCH loop that never
+        # exits, which would hang the pod at Init:.../1 forever.
+        initDatasources: true
+        restartPolicy: Always
   alertmanager:
     # No `config:` block here — deliberately left as the chart's own
     # default (null receiver + Watchdog->null + standard inhibit_rules).


### PR DESCRIPTION
## Summary
- Root-caused why the new Loki datasource (from #4698) never showed up in Grafana even though the ConfigMap and rendered `datasource.yaml` file were correct.
- `grafana-sc-datasources` starts concurrently with the `grafana` container. Grafana provisions datasources **once** at boot (no rewatch, unlike dashboards which do rescan every ~30s) — confirmed live via logs/timestamps that the sidecar's first write (`10:13:56.128`) landed after Grafana's provisioning scan had already run. Confirmed not self-healing (same pod, 3+ min later, still only 2 datasources).
- Existing datasources (Prometheus/Alertmanager) were unaffected only because they're already persisted in Grafana's long-lived DB (511-day-old PVC) from the original install — this race has likely always existed, just never mattered until a brand-new datasource was added.
- Fix: `sidecar.datasources.initDatasources: true` + `restartPolicy: Always` makes the sidecar a Kubernetes **native sidecar** (stable since 1.29; cluster runs 1.35.6) — it completes its first sync before Grafana's main container starts, then keeps watching for future ConfigMap changes exactly as before. Verified via `helm template` that `restartPolicy: Always` renders on the init container (required — without it, the sidecar's perpetual `WATCH` loop would never exit as a classic init container, hanging the pod at `Init:.../1` forever).

## Test plan
- [x] `helm template` confirms `grafana-init-sc-datasources` renders with `restartPolicy: Always`
- [x] `yamllint` passes under the repo's `.github/linters/.yamllint.yaml` config
- [ ] Post-merge: confirm Grafana pod restarts cleanly (not stuck in `Init`) and `/api/datasources` includes Loki