### PR TITLE
fix(prometheus-stack): add startupProbe to Grafana datasources init sidecar

### DIFF
--- a/cluster/apps/system/prometheus-stack/values.yaml
+++ b/cluster/apps/system/prometheus-stack/values.yaml
@@ -158,6 +158,22 @@ kube-prometheus-stack:
         # exits, which would hang the pod at Init:.../1 forever.
         initDatasources: true
         restartPolicy: Always
+        # restartPolicy: Always alone only guarantees the sidecar's container
+        # process has started before Grafana's container starts — it does NOT
+        # wait for the sidecar's initial ConfigMap sync to finish. Confirmed
+        # live: Grafana started 2s before the sidecar had actually finished
+        # writing datasource.yaml, so Loki was still missing after this fix
+        # alone. The sidecar's /healthz returns 503 until its initial sync
+        # completes (kiwigrid/k8s-sidecar's mark_ready()), so a startupProbe
+        # against it makes Kubernetes actually wait for real readiness, not
+        # just process start.
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 2
+          periodSeconds: 2
+          failureThreshold: 30
   alertmanager:
     # No `config:` block here — deliberately left as the chart's own
     # default (null receiver + Watchdog->null + standard inhibit_rules).


### PR DESCRIPTION
## Summary
Follow-up to #4710. Verified live post-merge: the fix landed correctly (init container `grafana-init-sc-datasources` with `restartPolicy: Always`, ordering confirmed via container start timestamps), but Loki was **still** missing from `/api/datasources`.

Root cause of the remaining gap: `restartPolicy: Always` on a native sidecar only guarantees Kubernetes starts the sidecar's container process before the main container — it does **not** wait for the sidecar's actual work to finish, unless a `startupProbe` is configured. Confirmed via exact container timestamps: `grafana` started at `10:34:40`, but the sidecar didn't finish writing `datasource.yaml` until `10:34:43.294` — 3+ seconds later. Grafana's one-shot datasource provisioning scan ran before the file existed, same failure mode as before, just shifted a few seconds later.

Fetched the `kiwigrid/k8s-sidecar` source directly (`healthz.py`) to confirm `/healthz` returns `503 NOT READY` until `mark_ready()` fires internally — which the code comments explicitly tie to "initial sync done". A `startupProbe` against that endpoint (port `8082`, matching this sidecar's `HEALTH_PORT`) makes Kubernetes actually wait for the sync to complete before starting Grafana.

## Test plan
- [x] `helm template` confirms `startupProbe` renders on `grafana-init-sc-datasources` (port 8082, `restartPolicy: Always` preserved)
- [x] `yamllint` passes
- [ ] Post-merge: confirm Grafana restarts cleanly and `/api/datasources` includes Loki this time