### PR TITLE
fix(alloy): tolerate nv1's NoSchedule taint on the k8s-logs DaemonSet

### DIFF
--- a/cluster/apps/system/alloy/k8s-logs/values.yaml
+++ b/cluster/apps/system/alloy/k8s-logs/values.yaml
@@ -52,3 +52,13 @@ alloy:
         }
   controller:
     type: daemonset
+    # nv1 (Jetson arm64 worker) carries a custom NoSchedule taint reserved
+    # for AI/GPU workloads (same pattern as smartmon-exporter's toleration)
+    # — without this, the DaemonSet only reaches the 3 amd64 control-plane
+    # nodes and silently skips nv1 entirely (confirmed live: 3/3 ready,
+    # not 4/4).
+    tolerations:
+      - key: nv
+        operator: Equal
+        value: NoSchedule
+        effect: NoSchedule


### PR DESCRIPTION
## Summary
Verified live post-merge of #4698: Grafana Loki datasource works and Loki + router syslog logs are flowing correctly. But the `alloy-k8s-logs` DaemonSet only shows `3/3` ready, not the `4/4` the original design/plan called for (all nodes incl. arm64 `nv1`).

Root cause: `nv1` carries a custom taint `nv=NoSchedule:NoSchedule` (reserved for AI/GPU workloads — confirmed via `kubectl get node nv1 -o jsonpath='{.spec.taints}'`), which the Alloy DaemonSet had no toleration for. `smartmon-exporter` already has the exact same toleration for the same reason (`cluster/apps/system/smartmon-exporter/values.yaml`), so this follows established repo precedent.

## Test plan
- [x] `helm template` confirms the toleration renders correctly on the DaemonSet pod spec
- [x] `yamllint` passes
- [ ] Post-merge: confirm `alloy-k8s-logs` DaemonSet reaches `4/4` including a pod on `nv1`