### PR TITLE
fix(loki): raise max_line_size to stop dropping rook-ceph-mgr logs

### DIFF
--- a/cluster/apps/system/loki/values.yaml
+++ b/cluster/apps/system/loki/values.yaml
@@ -16,6 +16,12 @@ loki:
       type: filesystem
     limits_config:
       retention_period: 720h
+      # Default (256KB) silently drops every log line rook-ceph-mgr emits
+      # above that size — confirmed live, recurring every ~15-25s
+      # ("max entry size '262144' bytes exceeded ... length '589221' bytes"
+      # for stream {container="mgr", pod="rook-ceph-mgr-a-..."}). Raised
+      # comfortably above the largest observed line (~576KiB).
+      max_line_size: 1MB
     compactor:
       retention_enabled: true
       delete_request_store: filesystem


### PR DESCRIPTION
## Summary
Health/error-log audit of the newly deployed logging stack found one active, recurring issue: Loki's default `limits_config.max_line_size` (256KB) was silently discarding every log line `rook-ceph-mgr` emits above that size — confirmed live, recurring every ~15-25s in both Loki's own logs and as "dropping data" errors on the Alloy DaemonSet:

```
max entry size '262144' bytes exceeded for stream '{container="mgr", pod="rook-ceph-mgr-a-..."}'
while adding an entry with length '589221' bytes
```

102 occurrences in the last ~2000 log lines checked, still actively happening. Per upstream Loki docs (`grafana/loki` troubleshooting guide via Context7), the two options are raising `max_line_size` or truncating; raising it is simplest here since the offending lines are a known, bounded size (~400-589KB observed).

Set `max_line_size: 1MB` — comfortably above the largest observed line (~576KiB).

Everything else in the stack is clean: all 4 apps `Synced`/`Healthy`, zero pod restarts, `alloy-router-syslog` and Grafana have no errors, and a one-time burst of "timestamp too old" rejections at Alloy's initial startup (backfilling weeks-old on-disk logs past Loki's 7-day cutoff) is expected/benign and didn't recur.

## Test plan
- [x] `helm template` confirms `max_line_size: 1MB` renders in Loki's config
- [x] `yamllint` passes
- [ ] Post-merge: confirm the "max entry size exceeded" errors for rook-ceph-mgr stop appearing in Loki's logs