### PR TITLE
fix(nextcloud): grant cnpg_metrics_exporter CONNECT on app database

### DIFF
--- a/cluster/apps/default/nextcloud/app/values.yaml
+++ b/cluster/apps/default/nextcloud/app/values.yaml
@@ -13,6 +13,21 @@ pgsql-cnpg:
       cpu: 500m
   monitoring:
     enablePodMonitor: true
+  # The `app` database's PUBLIC CONNECT grant was revoked out-of-band at
+  # some point (confirmed live: `\l+ app` shows only `app=CTc/app`, no
+  # PUBLIC entry, unlike every other CNPG database in this cluster). That
+  # silently broke cnpg_metrics_exporter (member of pg_monitor, but never
+  # had CONNECT on `app` to begin with) — confirmed via Loki: every
+  # metrics scrape failed with "permission denied for database \"app\""
+  # (SQLSTATE 42501), on both instances, continuously. Applied live via
+  # `kubectl exec ... psql -U postgres -d app -c "GRANT CONNECT ..."`.
+  # This only documents the grant for a future bootstrap (e.g. disaster
+  # recovery from backup) — postInitApplicationSQL runs once at cluster
+  # creation, not on the already-running cluster.
+  bootstrap:
+    initdb:
+      postInitApplicationSQL:
+        - GRANT CONNECT ON DATABASE app TO cnpg_metrics_exporter
   retentionPolicy: "7d"
   objectStore:
     destinationPath: "s3://k8s-at-home-backup/cnpg/nextcloud"


### PR DESCRIPTION
## Summary
Found via the new Loki-based cross-cluster log audit: `nextclouddb-cnpg` was failing **every** metrics scrape, continuously, on both instances — `permission denied for database "app"` (SQLSTATE 42501) — invisible to Prometheus/pod-health the whole time (pods were `Running`/healthy, no alert fired).

Root cause: live inspection (`\l+ app`) showed the `app` database's `PUBLIC` `CONNECT` grant had been revoked out-of-band at some point — `app=CTc/app` only, no `PUBLIC` entry — unlike every other CNPG database in this cluster (`onlyoffice`, same Postgres image version, shows the normal default/no-explicit-ACL state). `cnpg_metrics_exporter` is correctly a `pg_monitor` member, but that only grants stats visibility *after* connecting; it never had `CONNECT` on `app` to begin with.

**Already applied live** (with explicit confirmation): `GRANT CONNECT ON DATABASE app TO cnpg_metrics_exporter` — verified via `\l+ app` and confirmed zero exporter errors in Loki afterward.

This PR just documents the grant via `bootstrap.initdb.postInitApplicationSQL` (same pattern `bookorbit` already uses) so a future cluster recreation (e.g. disaster recovery from backup) doesn't silently reintroduce the same gap. It does **not** affect the already-running cluster — bootstrap SQL only runs once at creation.

## Test plan
- [x] `helm template` confirms `postInitApplicationSQL` renders in the Cluster spec
- [x] `yamllint` passes
- [x] Live grant verified via `\l+ app` and confirmed via Loki — zero "permission denied" errors since