### PR TITLE
fix(rook-ceph): reduce SSD wear via compression and async discard

### DIFF
--- a/cluster/apps/core/rook-ceph/cluster/values.yaml
+++ b/cluster/apps/core/rook-ceph/cluster/values.yaml
@@ -6,6 +6,12 @@ rook-ceph-cluster:
   configOverride: |
     [mon]
     mon_data_avail_warn = 10
+    [osd]
+    # Async TRIM/discard lets the SSD firmware reclaim freed blocks
+    # proactively instead of only on overwrite, reducing internal write
+    # amplification (and thus wear) on the consumer-grade Crucial MX500
+    # drives backing the OSDs. Async (not sync) avoids adding op latency.
+    bdev_async_discard = true
   monitoring:
     enabled: true
     createPrometheusRules: true
@@ -102,6 +108,12 @@ rook-ceph-cluster:
         failureDomain: host
         replicated:
           size: 3
+        # ceph-blockpool carries nearly all cluster write traffic (RBD PVCs);
+        # compression here directly cuts bytes written to the SSDs, reducing
+        # wear on the consumer-grade Crucial MX500 OSD drives.
+        parameters:
+          compression_mode: aggressive
+          compression_algorithm: lz4
       storageClass:
         enabled: true
         name: ceph-block


### PR DESCRIPTION
## Summary
- Enable `aggressive` lz4 compression on `ceph-blockpool` (the RBD pool backing nearly all cluster write traffic) to cut bytes actually written to the OSD SSDs.
- Enable `bdev_async_discard` on OSDs so the SSD firmware can proactively reclaim freed blocks, reducing internal write amplification.

Both target the consumer-grade Crucial MX500 drives backing the Ceph OSDs (mc1/mc2/mc3), currently at 60-68% SMART wear, found while investigating a transient `BLUESTORE_SLOW_OP_ALERT` on `osd.2` (mc3) triggered by a deep-scrub.

## Test plan
- [x] Rendered chart with `helm template` — confirmed `CephBlockPool` includes `parameters.compression_mode: aggressive` / `compression_algorithm: lz4`, and `configOverride` includes `[osd] bdev_async_discard = true`.
- [ ] After merge/sync, verify with `ceph osd pool get ceph-blockpool compression_mode` and `ceph config get osd bdev_async_discard` on the live cluster.
- [ ] Monitor SATA SSD wear trend (`smartctl_device_attribute{attribute_name="Percent_Lifetime_Remain"}`) over following weeks to confirm reduced growth rate.