### PR TITLE
fix(devcontainer): export XDG_CONFIG_HOME before brew trust in install_user.sh

### DIFF
--- a/.github/.devcontainer/local-features/common/install_user.sh
+++ b/.github/.devcontainer/local-features/common/install_user.sh
@@ -2,6 +2,11 @@
 
 export PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH"
 
+# .envrc sets this via direnv for every later shell in the repo; brew's tap/formula
+# trust store location depends on it, so it must match here too or trust granted
+# during image build won't be found once direnv is active (see task init failures).
+export XDG_CONFIG_HOME="$HOME/.config"
+
 /home/linuxbrew/.linuxbrew/bin/brew update
 /home/linuxbrew/.linuxbrew/bin/brew trust go-task/tap
 /home/linuxbrew/.linuxbrew/bin/brew trust hashicorp/tap


### PR DESCRIPTION
## Summary
- `task init` (`brew bundle upgrade`) was failing in fresh devcontainers with "Refusing to load formula ... from untrusted tap" for `go-task/tap`, `hashicorp/tap`, and `int128/kubelogin`.
- Root cause: `install_user.sh` runs `brew trust` during image build before `XDG_CONFIG_HOME` is set, so trust is recorded at `~/.homebrew/trust.json`. `.envrc` sets `XDG_CONFIG_HOME=~/.config` via direnv for every later shell in the repo, which moves brew's trust store lookup to `~/.config/homebrew/trust.json` — a location that was never populated, so the taps read as untrusted the first time `task init` runs through a direnv-loaded shell.
- Fix: export `XDG_CONFIG_HOME` in `install_user.sh` to match `.envrc` before running `brew trust`/`brew bundle install`, so the trust store lands where brew will actually look for it afterward.

## Test plan
- [x] Reproduced on the current devcontainer: found `~/.homebrew/trust.json` (populated) vs `~/.config/homebrew/trust.json` (missing), confirming the mismatch.
- [x] Re-ran `brew trust --tap ...` under the direnv-loaded env and confirmed `task init` now completes successfully.
- [ ] Fresh devcontainer rebuild (CI/new codespace) to confirm `task init` succeeds on first run without manual `brew trust`.