### PR TITLE
feat(nv1): reconcile taints, tolerations and stale config

### DIFF
--- a/cluster/apps/core/rook-ceph/csi-drivers/values.yaml
+++ b/cluster/apps/core/rook-ceph/csi-drivers/values.yaml
@@ -49,6 +49,15 @@ ceph-csi-drivers:
           logRotator: {}
           addons: {}
       nodePlugin:
+        tolerations:
+          - key: nv
+            operator: Equal
+            value: NoSchedule
+            effect: NoSchedule
+          - key: nvidia.com/gpu
+            operator: Equal
+            value: present
+            effect: NoSchedule
         resources:
           plugin:
             requests:
@@ -105,6 +114,15 @@ ceph-csi-drivers:
           logRotator: {}
           addons: {}
       nodePlugin:
+        tolerations:
+          - key: nv
+            operator: Equal
+            value: NoSchedule
+            effect: NoSchedule
+          - key: nvidia.com/gpu
+            operator: Equal
+            value: present
+            effect: NoSchedule
         resources:
           plugin:
             requests:

--- a/cluster/apps/system/node-feature-discovery/values.yaml
+++ b/cluster/apps/system/node-feature-discovery/values.yaml
@@ -9,6 +9,15 @@ node-feature-discovery:
       limits:
         memory: 33M
   worker:
+    tolerations:
+      - key: nv
+        operator: Equal
+        value: NoSchedule
+        effect: NoSchedule
+      - key: nvidia.com/gpu
+        operator: Equal
+        value: present
+        effect: NoSchedule
     resources:
       requests:
         cpu: 5m

--- a/cluster/apps/system/prometheus-stack/templates/metrics-proxy.yaml
+++ b/cluster/apps/system/prometheus-stack/templates/metrics-proxy.yaml
@@ -56,27 +56,35 @@ spec:
     spec:
       hostNetwork: true
       tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - key: nv
+          operator: Equal
+          value: NoSchedule
+          effect: NoSchedule
+        - key: nvidia.com/gpu
+          operator: Equal
+          value: present
+          effect: NoSchedule
       containers:
-      - name: metrics-proxy
-        image: haproxy:3.4-alpine@sha256:fb87fc81943143b9acaea7442973e6ba654035fff76ffe7af6829dd1bcb0f7a5
-        resources:
-          limits:
-            memory: 200Mi
-          requests:
-            cpu: 50m
-            memory: 175Mi
-        volumeMounts:
-        - name: config
-          mountPath: /usr/local/etc/haproxy
-        env:
-        - name: NODE_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.hostIP
+        - name: metrics-proxy
+          image: haproxy:3.4-alpine@sha256:fb87fc81943143b9acaea7442973e6ba654035fff76ffe7af6829dd1bcb0f7a5
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 50m
+              memory: 175Mi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/etc/haproxy
+          env:
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
       terminationGracePeriodSeconds: 30
       volumes:
         - name: config

--- a/cluster/apps/system/smartmon-exporter/values.yaml
+++ b/cluster/apps/system/smartmon-exporter/values.yaml
@@ -52,6 +52,10 @@ prometheus-smartctl-exporter:
           operator: Equal
           value: NoSchedule
           effect: NoSchedule
+        - key: nvidia.com/gpu
+          operator: Equal
+          value: present
+          effect: NoSchedule
       resources:
         requests:
           cpu: 10m


### PR DESCRIPTION
Phase 0 of the Jetson iGPU work. See docs/superpowers/specs/2026-08-13-jetson-igpu-design.md.

Widens tolerations so workloads that must reach nv1 tolerate both the current nv taint and the incoming nvidia.com/gpu taint.