### PR TITLE
chore(nv1): drop transitional nv toleration, rename taint template

### DIFF
--- a/cluster/apps/core/rook-ceph/csi-drivers/values.yaml
+++ b/cluster/apps/core/rook-ceph/csi-drivers/values.yaml
@@ -50,10 +50,6 @@ ceph-csi-drivers:
           addons: {}
       nodePlugin:
         tolerations:
-          - key: nv
-            operator: Equal
-            value: NoSchedule
-            effect: NoSchedule
           - key: nvidia.com/gpu
             operator: Equal
             value: present
@@ -115,10 +111,6 @@ ceph-csi-drivers:
           addons: {}
       nodePlugin:
         tolerations:
-          - key: nv
-            operator: Equal
-            value: NoSchedule
-            effect: NoSchedule
           - key: nvidia.com/gpu
             operator: Equal
             value: present

--- a/cluster/apps/system/node-feature-discovery/values.yaml
+++ b/cluster/apps/system/node-feature-discovery/values.yaml
@@ -10,10 +10,6 @@ node-feature-discovery:
         memory: 33M
   worker:
     tolerations:
-      - key: nv
-        operator: Equal
-        value: NoSchedule
-        effect: NoSchedule
       - key: nvidia.com/gpu
         operator: Equal
         value: present

--- a/cluster/apps/system/prometheus-stack/templates/metrics-proxy.yaml
+++ b/cluster/apps/system/prometheus-stack/templates/metrics-proxy.yaml
@@ -59,10 +59,6 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule
-        - key: nv
-          operator: Equal
-          value: NoSchedule
-          effect: NoSchedule
         - key: nvidia.com/gpu
           operator: Equal
           value: present

--- a/cluster/apps/system/smartmon-exporter/values.yaml
+++ b/cluster/apps/system/smartmon-exporter/values.yaml
@@ -48,10 +48,6 @@ prometheus-smartctl-exporter:
                     operator: In
                     values: [nv1]
       tolerations:
-        - key: nv
-          operator: Equal
-          value: NoSchedule
-          effect: NoSchedule
         - key: nvidia.com/gpu
           operator: Equal
           value: present

--- a/provision/talos/templates/worker.yaml
+++ b/provision/talos/templates/worker.yaml
@@ -57,7 +57,8 @@ machine:
     topology.kubernetes.io/region: home
     topology.kubernetes.io/zone: m
   nodeTaints:
-    nv: :NoSchedule
+    # value:effect — parsed by Talos labels.ParseTaint (strings.Cut on ":")
+    nvidia.com/gpu: present:NoSchedule
 cluster:
   id: ${TALHELPER_CLUSTERNAME}
   secret: ${TALHELPER_CLUSTERSECRET}


### PR DESCRIPTION
Phase 0 of the Jetson iGPU work (Tasks 3 & 6). See docs/superpowers/specs/2026-08-13-jetson-igpu-design.md.

- Renames the Talos worker template's nodeTaint key from `nv` to `nvidia.com/gpu` (Task 3).
- Removes the now-unnecessary transitional `nv` toleration from the four workloads widened in #4894, now that nv1 carries only `nvidia.com/gpu=present:NoSchedule` (Task 6).

Note: nv1's live taint was set manually via `kubectl taint` rather than by Talos's config controller — Kubernetes' NodeRestriction admission controller blocks a kubelet from modifying `.spec.taints` on its own already-registered Node object, so Talos can only apply nodeTaints at initial node registration, not via a later config update. Confirmed via dmesg: the `k8s.NodeApplyController` repeatedly failed with "not allowed to modify taints" until the taint was set out-of-band; a follow-up config reapply then converged cleanly with no further errors.