### PR TITLE
feat(jetson): enable Jetson Orin NX iGPU (Phase 1 — Tasks 8-11)

### DIFF
--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -215,8 +215,10 @@ tasks:
       TALOS_IMAGE:
         sh: yq ea '[.machine.install.image].[0]' < "{{.FILE}}"
       FORCE: "{{ .FORCE | default false }}"
+      NODE_TALOS_VERSION:
+        sh: yq '.nodes[] | select(.name == "{{ .N }}") | .talosVersion // "{{ .TALOS_VERSION }}"' < {{.TALOS_DIR}}/nodes.yaml
     status:
-      - $([ "{{ .FORCE }}" = "false" ] && talosctl version --nodes {{ .NODE }} --short | grep -q 'Tag.*{{ .TALOS_VERSION }}' || return 1)
+      - $([ "{{ .FORCE }}" = "false" ] && talosctl version --nodes {{ .NODE }} --short | grep -q 'Tag.*{{ .NODE_TALOS_VERSION }}' || return 1)
     cmds:
       - task: wait_for_health
         vars: {TIMEOUT: 10m}

--- a/cluster/apps/system/nvidia/app-config.yaml
+++ b/cluster/apps/system/nvidia/app-config.yaml
@@ -1,0 +1,10 @@
+- enabled: "true"
+  namespace: nvidia-system
+  syncWave: "2"
+  syncPolicy:
+    enabled: true
+    selfHeal: true
+    prune: false
+  managedNamespaceMetadata:
+    labels:
+      pod-security.kubernetes.io/enforce: privileged

--- a/cluster/apps/system/nvidia/kustomization.yaml
+++ b/cluster/apps/system/nvidia/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nvidia-system
+resources:
+  - resources/cdi-setup.yaml
+  - resources/device-plugin.yaml
+  - resources/power-mode.yaml

--- a/cluster/apps/system/nvidia/resources/cdi-setup.yaml
+++ b/cluster/apps/system/nvidia/resources/cdi-setup.yaml
@@ -1,0 +1,302 @@
+---
+# nvidia-cdi-setup — one-time GPU system setup + CDI spec writer
+#
+# Runs on every node at system-node-critical priority and handles all setup
+# required before CUDA containers can start:
+#
+#   1. Restores JetPack r36.5 userspace libraries to /var/lib/nvidia-tegra-libs/tegra/
+#      (replaces gpu-libs-restore DaemonSet + the libs initContainer in the legacy manifest)
+#
+#   2. Copies GPU firmware from the read-only rootfs to NVMe /var/fw-fresh and
+#      redirects firmware_class.path to avoid -ETXTBSY on squashfs inodes
+#
+#   3. Creates /dev/nvhost-ctrl symlink → /dev/nvgpu/igpu0/ctrl
+#      (JetPack 6 libcuda.so.1.1 requires this during cuInit)
+#
+#   4. Writes /var/run/cdi/nvidia-jetson.yaml — the CDI spec containerd reads
+#      when a pod requests nvidia.com/gpu.  The spec is generated dynamically
+#      so it only lists device nodes that actually exist on this host.
+#
+#
+# Apply:
+#   kubectl apply -f manifests/gpu/cdi-setup.yaml
+#   (called automatically by scripts/10-setup-cdi.sh)
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nvidia-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+---
+# Shell scripts are stored in a ConfigMap to keep the DaemonSet YAML readable
+# and avoid any YAML escaping issues with complex heredocs / multi-line strings.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nvidia-cdi-setup-scripts
+  namespace: nvidia-system
+data:
+  # ── restore-libs.sh ───────────────────────────────────────────────────────
+  # Downloads real JetPack r36.5 userspace libs from NVIDIA APT into
+  # /var/lib/nvidia-tegra-libs/tegra/ if missing or stale.
+  restore-libs.sh: |
+    #!/bin/sh
+    set -e
+    DEST=/nvidia-libs/tegra
+    CUDA_LIB="${DEST}/libcuda.so.1.1"
+    MIN_SIZE=1000000   # real libcuda.so.1.1 is ~41 MB; 0-byte stubs are 0
+
+    if [ -f "${CUDA_LIB}" ] && \
+       [ "$(stat -c%s "${CUDA_LIB}" 2>/dev/null || echo 0)" -gt "${MIN_SIZE}" ]; then
+      echo "JetPack r36.5 libs already present ($(ls "${DEST}" | wc -l) files). Skipping."
+      exit 0
+    fi
+
+    echo "JetPack libs missing or stale — installing from NVIDIA APT r36.5..."
+    apt-get update -qq && apt-get install -y -qq curl dpkg
+
+    rm -rf "${DEST}" && mkdir -p "${DEST}"
+    cd /tmp
+
+    BASE="https://repo.download.nvidia.com/jetson/t234/pool/main/n"
+    VER="36.5.0-20260115194252"
+
+    curl -fsSL -o l4t-core.deb \
+      "${BASE}/nvidia-l4t-core/nvidia-l4t-core_${VER}_arm64.deb"
+    curl -fsSL -o l4t-cuda.deb \
+      "${BASE}/nvidia-l4t-cuda/nvidia-l4t-cuda_${VER}_arm64.deb"
+    curl -fsSL -o l4t-3d.deb \
+      "${BASE}/nvidia-l4t-3d-core/nvidia-l4t-3d-core_${VER}_arm64.deb"
+
+    for pkg in l4t-core.deb l4t-cuda.deb l4t-3d.deb; do
+      dpkg-deb -x "${pkg}" "/tmp/extract-${pkg}/"
+      find "/tmp/extract-${pkg}" \
+        \( -path '*/aarch64-linux-gnu/tegra/*' \
+        -o -path '*/aarch64-linux-gnu/nvidia/*' \) \
+        -type f -exec cp {} "${DEST}/" \;
+      rm -rf "/tmp/extract-${pkg}/" "${pkg}"
+    done
+
+    # Ensure libcuda.so.1 symlink exists
+    ln -sf libcuda.so.1.1 "${DEST}/libcuda.so.1" 2>/dev/null || true
+
+    echo "Done. $(ls "${DEST}" | wc -l) libs installed."
+    echo "  libcuda.so.1.1 : $(stat -c%s "${DEST}/libcuda.so.1.1" 2>/dev/null || echo MISSING) bytes"
+    echo "  libnvrm_gpu.so : $(stat -c%s "${DEST}/libnvrm_gpu.so"  2>/dev/null || echo MISSING) bytes"
+
+  # ── cdi-writer.sh ─────────────────────────────────────────────────────────
+  # Runs in the long-lived container: sets up firmware, device symlinks, device
+  # permissions, and writes the CDI spec.  Loops every 60 s to regenerate the
+  # spec if /var/run is cleared (tmpfs reset after host reboot).
+  cdi-writer.sh: |
+    #!/bin/sh
+    set -e
+
+    CDI_DIR=/var/run/cdi
+    CDI_SPEC="${CDI_DIR}/nvidia-jetson.yaml"
+    FW_SRC=/host-firmware/ga10b
+    FW_DEST=/host-var/fw-fresh/ga10b
+
+    write_cdi_spec() {
+      mkdir -p "${CDI_DIR}"
+
+      # Open the spec file and write each section with echo/printf.
+      # We avoid heredocs because the YAML-in-YAML nesting makes indentation
+      # tricky; individual echo statements are unambiguous.
+
+      {
+        echo 'cdiVersion: "0.5.0"'
+        echo 'kind: "nvidia.com/gpu"'
+        echo 'devices:'
+        echo '  - name: "0"'
+        echo '    containerEdits:'
+        echo '      deviceNodes:'
+        # Device strategy: inject all nvgpu/* devices + /dev/dri/renderD128.
+        #
+        # /dev/dri/renderD128 is the DRM render node created by tegra-drm.ko (OE4T build).
+        # JetPack 6 libcuda.so opens this node during cuInit to enumerate the iGPU.
+        # Without it, cuInit returns 801 (CUDA_ERROR_NOT_SUPPORTED).
+        #
+        # /dev/nvhost-ctrl is only injected when a real char device exists (shim loaded).
+        # The fallback symlink (→ /dev/nvgpu/igpu0/ctrl) is excluded: CDI rejects symlinks.
+
+        # All /dev/nvgpu/igpu0/* char devices
+        for dev in $(find /dev/nvgpu/igpu0/ -type c 2>/dev/null | sort); do
+          printf '        - path: %s\n          permissions: rw\n' "${dev}"
+        done
+
+        # /dev/nvmap — required for GPU memory allocation
+        if [ -c /dev/nvmap ]; then
+          printf '        - path: /dev/nvmap\n          permissions: rw\n'
+        fi
+
+        # /dev/nvhost-ctrl: only inject when it is a real char device (shim loaded).
+        # The fallback symlink created when shim is absent (→ /dev/nvgpu/igpu0/ctrl)
+        # must NOT be injected: CDI rejects symlinks with "not a device node".
+        # /dev/nvgpu/igpu0/ctrl is already in the spec above, so nothing is lost.
+        if [ -c /dev/nvhost-ctrl ] && [ ! -L /dev/nvhost-ctrl ]; then
+          printf '        - path: /dev/nvhost-ctrl\n          permissions: rw\n'
+        fi
+
+        # /dev/dri/renderD128: DRM render node created by tegra-drm.ko (OE4T build).
+        # Required by JetPack 6 libcuda.so for GPU enumeration on Tegra (cuInit).
+        # Inject only when the node actually exists (requires tegra-drm extension).
+        if [ -c /dev/dri/renderD128 ]; then
+          printf '        - path: /dev/dri/renderD128\n          permissions: rw\n'
+        fi
+        echo '      mounts:'
+        echo '        # Bind-mount the entire JetPack r36.5 library directory.'
+        echo '        # Replaces all individual hostPath lib mounts in the legacy manifest.'
+        echo '        - hostPath: /var/lib/nvidia-tegra-libs/tegra'
+        echo '          containerPath: /usr/lib/aarch64-linux-gnu/nvidia'
+        echo '          options: [ro, bind]'
+        echo '      env:'
+        echo '        # Prepend r36.5 libs so they shadow any 0-byte stubs in the image.'
+        echo '        - "LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu/nvidia:/usr/local/cuda/lib:/usr/local/cuda/lib64:/usr/local/cuda/compat"'
+        # containerEdits at spec root must be an object (ContainerEdits), not an
+        # array.  Omit it entirely — it is optional and defaults to empty.
+        # (Writing 'containerEdits: []' causes containerd to reject the spec with
+        #  "cannot unmarshal array into Go struct field Spec.containerEdits")
+      } > "${CDI_SPEC}"
+
+      DEV_COUNT=$(grep -c 'path: /dev/' "${CDI_SPEC}" 2>/dev/null || echo 0)
+      echo "[cdi-setup] CDI spec written: ${CDI_SPEC} (${DEV_COUNT} device nodes)"
+    }
+
+    # ── Firmware copy (idempotent) ─────────────────────────────────────────
+    if [ ! -f "${FW_DEST}/gpmu_ucode_next_prod_image.bin" ]; then
+      echo "[cdi-setup] Copying GPU firmware to NVMe /var/fw-fresh..."
+      mkdir -p "${FW_DEST}"
+      cp "${FW_SRC}/"* "${FW_DEST}/" 2>/dev/null || true
+    fi
+    echo "[cdi-setup] Redirecting firmware_class.path -> /var/fw-fresh"
+    echo -n '/var/fw-fresh' > /sys/module/firmware_class/parameters/path
+
+    # ── Device symlink (legacy compat only) ───────────────────────────────
+    # Create /dev/nvhost-ctrl symlink → /dev/nvgpu/igpu0/ctrl for any legacy
+    # code that still opens /dev/nvhost-ctrl. Does not affect CUDA (which uses
+    # /dev/dri/renderD128 via tegra-drm). CDI does not inject this symlink.
+    if [ ! -c /dev/nvhost-ctrl ] && [ ! -L /dev/nvhost-ctrl ]; then
+      if [ -e /dev/nvgpu/igpu0/ctrl ]; then
+        ln -sf /dev/nvgpu/igpu0/ctrl /dev/nvhost-ctrl
+        echo "[cdi-setup] created /dev/nvhost-ctrl symlink (legacy compat)"
+      fi
+    fi
+
+    # ── Device permissions (dynamic — covers NVHOST=n and NVHOST=y) ───────
+    for dev in \
+        $(find /dev/nvgpu/ -type c 2>/dev/null) \
+        $(find /dev/ -maxdepth 1 -name 'nvhost-*' 2>/dev/null) \
+        /dev/nvmap; do
+      if [ -e "${dev}" ]; then chmod 666 "${dev}" 2>/dev/null || true; fi
+    done
+
+    # ── Initial CDI spec write ─────────────────────────────────────────────
+    write_cdi_spec
+    echo "[cdi-setup] Setup complete — entering watch loop (60 s interval)"
+
+    # ── Watch loop: regenerate spec if /var/run is cleared ─────────────────
+    while true; do
+      sleep 60
+      if [ ! -f "${CDI_SPEC}" ]; then
+        echo "[cdi-setup] CDI spec missing — regenerating..."
+        write_cdi_spec
+      fi
+    done
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-cdi-setup
+  namespace: nvidia-system
+  labels:
+    app: nvidia-cdi-setup
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  selector:
+    matchLabels:
+      app: nvidia-cdi-setup
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: nvidia-cdi-setup
+    spec:
+      nodeSelector:
+        accelerator: jetson-orin
+      tolerations:
+        - operator: Exists
+      priorityClassName: system-node-critical
+      hostPID: true
+
+      # ── Step 1: Restore JetPack r36.5 libs (once per boot) ──────────────
+      initContainers:
+        - name: restore-libs
+          image: ubuntu:22.04@sha256:a8cdd2158a73d7e5c02aa351fe269f48f57cf710a241db86e9ede371fc150149
+          command: ["/bin/bash", "/scripts/restore-libs.sh"]
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: nvidia-libs
+              mountPath: /nvidia-libs
+            - name: scripts
+              mountPath: /scripts
+
+      # ── Step 2: Firmware + device setup + CDI spec ──────────────────────
+      containers:
+        - name: cdi-writer
+          image: busybox:1.36@sha256:bd44eb136a95dcc8dc58995e43abc40a413f2e8e3d4a2aae6bccbe94686acb05
+          command: ["/bin/sh", "/scripts/cdi-writer.sh"]
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 5m
+              memory: 8Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+          volumeMounts:
+            - name: dev
+              mountPath: /dev
+            - name: sys
+              mountPath: /sys
+            - name: host-firmware
+              mountPath: /host-firmware
+              readOnly: true
+            - name: host-var
+              mountPath: /host-var
+            - name: cdi-dir
+              mountPath: /var/run/cdi
+            - name: scripts
+              mountPath: /scripts
+
+      volumes:
+        - name: nvidia-libs
+          hostPath:
+            path: /var/lib/nvidia-tegra-libs
+            type: DirectoryOrCreate
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: host-firmware
+          hostPath:
+            path: /usr/lib/firmware
+        - name: host-var
+          hostPath:
+            path: /var
+        - name: cdi-dir
+          hostPath:
+            path: /var/run/cdi
+            type: DirectoryOrCreate
+        - name: scripts
+          configMap:
+            name: nvidia-cdi-setup-scripts
+            defaultMode: 0755

--- a/cluster/apps/system/nvidia/resources/device-plugin.yaml
+++ b/cluster/apps/system/nvidia/resources/device-plugin.yaml
@@ -1,0 +1,72 @@
+---
+# jetson-device-plugin — exposes nvidia.com/gpu as a Kubernetes extended resource
+#
+# Custom CDI-native device plugin for Jetson Orin (nvgpu 5.x, NVHOST=n).
+# Source: plugins/jetson-device-plugin/main.go
+#
+# Device injection strategy (CDI, two-layer):
+#   1. Kubernetes resource: requests nvidia.com/gpu: 1 → kubelet calls Allocate()
+#   2. AllocateResponse returns CDIDevices: [{Name: "nvidia.com/gpu=0"}]
+#   3. kubelet passes CDI device ID to containerd via CRI CDIDevices field
+#   4. containerd reads /var/run/cdi/nvidia-jetson.yaml (written by nvidia-cdi-setup)
+#      and injects all nvgpu + nvhost device nodes, JetPack r36.5 lib bind-mount,
+#      and LD_LIBRARY_PATH automatically — no hostPath mounts needed.
+#
+# Why custom plugin and not squat/generic-device-plugin:
+#   squat/generic-device-plugin does not support CDIDevices in AllocateResponse.
+#   containerd 2.x requires CDI devices via CRI CDIDevices field (pod annotations
+#   are NOT processed in containerd 2.x). A custom plugin is the minimal solution.
+#
+# Prerequisites:
+#   - nvidia-cdi-setup DaemonSet Running (CDI spec at /var/run/cdi/nvidia-jetson.yaml)
+#   - containerd with CDI enabled (machine-patch-cdi.yaml applied)
+#   - DevicePluginCDIDevices feature gate: GA in K8s 1.35 (enabled by default)
+#
+# Apply:
+#   kubectl apply -f manifests/gpu/device-plugin.yaml
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin
+  namespace: nvidia-system
+  labels:
+    app: nvidia-device-plugin
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  selector:
+    matchLabels:
+      app: nvidia-device-plugin
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: nvidia-device-plugin
+    spec:
+      nodeSelector:
+        accelerator: jetson-orin
+      tolerations:
+        - operator: Exists
+      priorityClassName: system-node-critical
+      containers:
+        - name: jetson-device-plugin
+          image: ghcr.io/schwankner/jetson-device-plugin:v1.0.0@sha256:9e362878dcc57d1349a65fc7de3578d9cd861c254f45ec19f33f9c781d2bdd08
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 5m
+              memory: 8Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins

--- a/cluster/apps/system/nvidia/resources/power-mode.yaml
+++ b/cluster/apps/system/nvidia/resources/power-mode.yaml
@@ -1,0 +1,245 @@
+# power-mode.yaml — Jetson Orin NX Power Mode DaemonSet
+#
+# Sets GPU and CPU clock limits at node startup via sysfs.
+# Defaults to MAXN mode (GPU 918 MHz, performance governor).
+#
+# ┌──────────────────────────────────────────────────────────────────────────┐
+# │  ⚠  MAXN SUPER is PERMANENTLY BLOCKED for Orin NX 16/8GB                │
+# │     The reComputer J401 carrier board cannot dissipate the heat of        │
+# │     MAXN SUPER. Enabling it WILL damage the module.                       │
+# │     Override only if you have a custom cooling solution:                  │
+# │       POWER_MODE=MAXN_SUPER + ALLOW_MAXN_SUPER=true                       │
+# └──────────────────────────────────────────────────────────────────────────┘
+#
+# Power modes (configure via POWER_MODE env var):
+#
+#   10W      4 CPU cores, GPU 612 MHz, powersave governor
+#   15W      4 CPU cores, GPU 612 MHz, nvhost_podgov (factory default)
+#   25W      8 CPU cores, GPU 408 MHz, nvhost_podgov
+#   MAXN     8 CPU cores, GPU 918 MHz, performance governor ← DEFAULT
+#   MAXN_SUPER  ⚠ BLOCKED on reComputer J401 without ALLOW_MAXN_SUPER=true
+#
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: jetson-power-mode
+  namespace: nvidia-system
+  labels:
+    app: jetson-power-mode
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  selector:
+    matchLabels:
+      app: jetson-power-mode
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: jetson-power-mode
+    spec:
+      nodeSelector:
+        accelerator: jetson-orin
+      tolerations:
+        - operator: Exists
+      priorityClassName: system-node-critical
+      containers:
+        - name: power-mode
+          image: busybox:1.36@sha256:bd44eb136a95dcc8dc58995e43abc40a413f2e8e3d4a2aae6bccbe94686acb05
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+
+              GPU_DEVFREQ=/sys/bus/platform/devices/17000000.gpu/devfreq/17000000.gpu
+              CPU_BASE=/sys/devices/system/cpu
+
+              POWER_MODE="${POWER_MODE:-MAXN}"
+              ALLOW_MAXN_SUPER="${ALLOW_MAXN_SUPER:-false}"
+
+              echo "[power-mode] Starting. POWER_MODE=${POWER_MODE}"
+
+              # ── MAXN SUPER guard ──────────────────────────────────────────
+              if [ "${POWER_MODE}" = "MAXN_SUPER" ] && [ "${ALLOW_MAXN_SUPER}" != "true" ]; then
+                echo "[power-mode] ⛔ MAXN_SUPER blocked — reComputer J401 cannot cool Orin NX 16/8GB at this TDP"
+                echo "[power-mode]    Falling back to MAXN. Set ALLOW_MAXN_SUPER=true only with custom cooling."
+                POWER_MODE=MAXN
+              fi
+
+              # ── Map mode → frequencies, governor, EMC ────────────────────
+              # GPU freq in Hz, CPU max_freq in kHz
+              # EMC_LOCK: whether to pin LPDDR5 to max rate (3199 MHz → ~68 GB/s)
+              #   true  → MAXN / MAXN_SUPER: full memory bandwidth for inference
+              #   false → 10W / 15W / 25W: let BPMP scale EMC freely (power saving)
+              case "${POWER_MODE}" in
+                10W)
+                  GPU_FREQ=612000000;  GPU_GOV=powersave
+                  CPU_MAX=1190400;     CORES=4;  EMC_LOCK=false ;;
+                15W)
+                  GPU_FREQ=612000000;  GPU_GOV=nvhost_podgov
+                  CPU_MAX=1420800;     CORES=4;  EMC_LOCK=false ;;
+                25W)
+                  GPU_FREQ=408000000;  GPU_GOV=nvhost_podgov
+                  CPU_MAX=1497600;     CORES=8;  EMC_LOCK=false ;;
+                MAXN)
+                  GPU_FREQ=918000000;  GPU_GOV=performance
+                  CPU_MAX=1984000;     CORES=8;  EMC_LOCK=true  ;;
+                MAXN_SUPER)
+                  # ALLOW_MAXN_SUPER=true was set — user accepts risk
+                  GPU_FREQ=1173000000; GPU_GOV=performance
+                  CPU_MAX=1984000;     CORES=8;  EMC_LOCK=true  ;;
+                *)
+                  echo "[power-mode] Unknown POWER_MODE=${POWER_MODE}, defaulting to MAXN"
+                  GPU_FREQ=918000000;  GPU_GOV=performance
+                  CPU_MAX=1984000;     CORES=8;  EMC_LOCK=true  ;;
+              esac
+
+              echo "[power-mode] GPU freq=${GPU_FREQ} Hz, governor=${GPU_GOV}, EMC lock=${EMC_LOCK}"
+              echo "[power-mode] CPU max=${CPU_MAX} kHz, cores=${CORES}"
+
+              EMC_CLK=/sys/kernel/debug/bpmp/debug/clk/emc
+
+              apply_settings() {
+                # ── GPU: set freq cap BEFORE switching governor ─────────────
+                if [ -d "${GPU_DEVFREQ}" ]; then
+                  # Write max_freq first (avoid min > max), then min
+                  echo "${GPU_FREQ}"  > "${GPU_DEVFREQ}/max_freq"
+                  echo "${GPU_FREQ}"  > "${GPU_DEVFREQ}/min_freq"
+                  echo "${GPU_GOV}"   > "${GPU_DEVFREQ}/governor"
+                  # With 'performance' governor, also set userspace target freq
+                  if [ "${GPU_GOV}" = "userspace" ]; then
+                    echo "${GPU_FREQ}" > "${GPU_DEVFREQ}/userspace/set_freq" 2>/dev/null || true
+                  fi
+                  CUR=$(cat "${GPU_DEVFREQ}/cur_freq" 2>/dev/null || echo "?")
+                  echo "[power-mode] GPU cur_freq=${CUR} Hz ✓"
+                else
+                  echo "[power-mode] ⚠ GPU devfreq not found at ${GPU_DEVFREQ}"
+                fi
+
+                # ── EMC (External Memory Controller) ───────────────────────
+                # MAXN / MAXN_SUPER: lock to 3199 MHz (full ~68 GB/s LPDDR5 bandwidth)
+                # 10W / 15W / 25W:   release lock → BPMP scales EMC freely (power saving)
+                #
+                # BPMP API (min_rate write returns EINVAL — use rate + mrq_rate_locked):
+                #   lock:    echo <max_rate> > rate && echo 1 > mrq_rate_locked
+                #   unlock:  echo 0 > mrq_rate_locked  (BPMP resumes DVFS)
+                if [ -f "${EMC_CLK}/rate" ] && [ -f "${EMC_CLK}/mrq_rate_locked" ]; then
+                  if [ "${EMC_LOCK}" = "true" ]; then
+                    EMC_MAX=$(cat "${EMC_CLK}/max_rate")
+                    echo "${EMC_MAX}" > "${EMC_CLK}/rate" 2>/dev/null && \
+                    echo 1            > "${EMC_CLK}/mrq_rate_locked" 2>/dev/null && \
+                      echo "[power-mode] EMC locked to ${EMC_MAX} Hz (max BW) ✓" || \
+                      echo "[power-mode] ⚠ EMC lock failed"
+                  else
+                    echo 0 > "${EMC_CLK}/mrq_rate_locked" 2>/dev/null && \
+                      echo "[power-mode] EMC unlocked — BPMP manages frequency (power saving)" || \
+                      echo "[power-mode] ⚠ EMC unlock failed"
+                  fi
+                else
+                  echo "[power-mode] ⚠ EMC debugfs not found"
+                fi
+
+                # ── CPU cores: hotplug ──────────────────────────────────────
+                TOTAL=$(ls -d ${CPU_BASE}/cpu[0-9]* 2>/dev/null | wc -l)
+                i=0
+                while [ $i -lt "${TOTAL}" ]; do
+                  HP="${CPU_BASE}/cpu${i}/online"
+                  if [ $i -lt "${CORES}" ]; then
+                    [ -f "${HP}" ] && echo 1 > "${HP}" 2>/dev/null || true
+                  else
+                    [ -f "${HP}" ] && echo 0 > "${HP}" 2>/dev/null || true
+                  fi
+                  i=$((i+1))
+                done
+
+                # ── CPU governor + scaling_max_freq ────────────────────────
+                # MAXN sets scaling_max_freq but leaves governor as 'schedutil'
+                # → CPU idles at 268 MHz between tokens (thread wakeup latency).
+                # 'performance' pins all cores at max_freq → eliminates wakeup
+                # latency for the Ollama server thread and CUDA callback threads.
+                for policy in $(ls -d ${CPU_BASE}/cpufreq/policy* 2>/dev/null); do
+                  echo "performance" > "${policy}/scaling_governor" 2>/dev/null || true
+                done
+                for cpu in $(ls -d ${CPU_BASE}/cpu[0-9]* 2>/dev/null); do
+                  MF="${cpu}/cpufreq/scaling_max_freq"
+                  [ -f "${MF}" ] && echo "${CPU_MAX}" > "${MF}" 2>/dev/null || true
+                done
+
+                ONLINE=$(cat "${CPU_BASE}/online" 2>/dev/null || echo "?")
+                CPU_GOV=$(cat "${CPU_BASE}/cpufreq/policy0/scaling_governor" 2>/dev/null || echo "?")
+                echo "[power-mode] CPUs online: ${ONLINE}, governor: ${CPU_GOV}"
+
+                # ── Transparent Huge Pages ──────────────────────────────────
+                # THP=always: kernel aggressively collapses 4K→2MB pages.
+                # Reduces TLB pressure for large CPU-side allocations:
+                # Go runtime (Ollama), KV cache, prompt eval buffers.
+                # GPU buffers on Jetson use nvmap (not mmap), so GPU decode
+                # is not affected — but CPU prompt eval benefits noticeably.
+                THP=/sys/kernel/mm/transparent_hugepage
+                if [ -f "${THP}/enabled" ]; then
+                  echo always > "${THP}/enabled"  2>/dev/null || true
+                  echo defer  > "${THP}/defrag"   2>/dev/null || true
+                  echo "[power-mode] THP enabled=always defrag=defer ✓"
+                fi
+              }
+
+              apply_settings
+              echo "[power-mode] Power mode ${POWER_MODE} applied ✓"
+
+              # Re-assert every 60s (governor/EMC may reset after suspend/resume)
+              while true; do
+                sleep 60
+                if [ -d "${GPU_DEVFREQ}" ]; then
+                  echo "${GPU_FREQ}" > "${GPU_DEVFREQ}/max_freq" 2>/dev/null || true
+                  echo "${GPU_FREQ}" > "${GPU_DEVFREQ}/min_freq" 2>/dev/null || true
+                  echo "${GPU_GOV}"  > "${GPU_DEVFREQ}/governor"  2>/dev/null || true
+                fi
+                if [ -f "${EMC_CLK}/rate" ] && [ -f "${EMC_CLK}/mrq_rate_locked" ]; then
+                  if [ "${EMC_LOCK}" = "true" ]; then
+                    EMC_MAX=$(cat "${EMC_CLK}/max_rate")
+                    echo "${EMC_MAX}" > "${EMC_CLK}/rate" 2>/dev/null || true
+                    echo 1            > "${EMC_CLK}/mrq_rate_locked" 2>/dev/null || true
+                  else
+                    echo 0 > "${EMC_CLK}/mrq_rate_locked" 2>/dev/null || true
+                  fi
+                fi
+                for policy in $(ls -d ${CPU_BASE}/cpufreq/policy* 2>/dev/null); do
+                  echo "performance" > "${policy}/scaling_governor" 2>/dev/null || true
+                done
+              done
+
+          env:
+            # ── Power mode: 10W | 15W | 25W | MAXN ─────────────────────────
+            # MAXN_SUPER is blocked unless ALLOW_MAXN_SUPER=true (see warning)
+            - name: POWER_MODE
+              value: "MAXN"
+            # ⚠ DANGER: set to "true" ONLY with custom cooling on Orin NX 16/8GB
+            - name: ALLOW_MAXN_SUPER
+              value: "false"
+
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 5m
+              memory: 4Mi
+            limits:
+              cpu: 20m
+              memory: 16Mi
+          volumeMounts:
+            - name: sys
+              mountPath: /sys
+            - name: debugfs
+              mountPath: /sys/kernel/debug
+      volumes:
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: debugfs
+          hostPath:
+            path: /sys/kernel/debug
+            type: Directory

--- a/docs/superpowers/plans/artifacts/2026-08-13-nv1-cpu-baseline.md
+++ b/docs/superpowers/plans/artifacts/2026-08-13-nv1-cpu-baseline.md
@@ -1,0 +1,44 @@
+# nv1 CPU Inference Baseline (2026-08-13)
+
+CPU-only figures, recorded before any GPU enablement work, from a throwaway
+`ollama/ollama:0.20.5` pod (`ollama-cpu-baseline`) scheduled on nv1 via
+`nodeSelector: kubernetes.io/hostname: nv1`, no GPU resources requested. Prompt
+for both models: "Write a haiku about storage." These are CPU-only numbers —
+the Jetson Orin NX's 8 A78AE cores, no GPU/CUDA involved.
+
+## qwen2.5:0.5b
+
+| Metric            | Value           |
+| ----------------- | --------------- |
+| eval rate         | 33.56 tokens/s  |
+| prompt eval rate  | 105.61 tokens/s |
+| eval count        | 18 tokens       |
+| prompt eval count | 36 tokens       |
+
+## qwen3.5:9b
+
+The default run (thinking mode enabled, the model's default) did not
+complete within 35+ minutes — `ollama ps` showed the runner pinned at
+100% CPU the entire time with no response yet. This is consistent with
+`qwen3.5` being a hybrid reasoning model that, left at its default
+settings, spends most of its token budget on internal "thinking" tokens
+before producing a final answer; at CPU speeds that made even a one-line
+haiku prompt impractically slow. The run was killed and repeated with
+`--think=false`:
+
+| Metric            | Value         |
+| ----------------- | ------------- |
+| eval rate         | 3.21 tokens/s |
+| prompt eval rate  | 6.00 tokens/s |
+| eval count        | 19 tokens     |
+| prompt eval count | 19 tokens     |
+
+**Note:** the default (thinking-enabled) case has no usable tok/s figure —
+it simply did not finish in a reasonable time on CPU. The `--think=false`
+numbers above are the only completed data point for this model, and even
+those are roughly an order of magnitude slower than qwen2.5:0.5b's rate, as
+expected for a model ~18x larger. Whichever mode Phase 1's GPU comparison
+ultimately uses (Task 13 pins `JETSON_JETPACK=6` but does not disable
+thinking), the CPU baseline for thinking-enabled generation should be
+treated as "impractically slow / effectively unusable," not as a specific
+number to beat.

--- a/provision/talos/nodes.yaml
+++ b/provision/talos/nodes.yaml
@@ -11,3 +11,6 @@ nodes:
   - name: nv1
     ip: 192.168.48.5
     type: worker
+    # Pinned: the GPU extension is ABI-bound to kernel 6.18.24.
+    # Remove this line only together with a rebuilt installer image.
+    talosVersion: v1.13.0

--- a/provision/talos/nodes/nv1.yaml
+++ b/provision/talos/nodes/nv1.yaml
@@ -9,3 +9,58 @@ machine:
         routes:
           - network: 0.0.0.0/0
             gateway: 192.168.50.1
+
+  install:
+    image: ghcr.io/schwankner/custom-installer:v1.13.0-6.18.24-nvgpu5.11.1-drm-noshim
+
+  kernel:
+    modules:
+      # OE4T host1x stack — prerequisite for all GPU modules
+      - name: host1x
+      - name: host1x_fence
+      - name: host1x_nvhost
+      # OE4T DRM stack — creates /dev/dri/renderD128, required for CUDA
+      - name: tegra_drm
+      # GPU memory + bandwidth
+      - name: nvmap
+      - name: mc_utils
+      # Main CUDA driver (GA10B / Ampere)
+      - name: nvgpu
+      # GPU frequency scaling governor
+      - name: governor_pod_scaling
+
+  nodeLabels:
+    accelerator: jetson-orin
+    nvidia.com/gpu.type: igpu
+
+  files:
+    # Talos builds containerd with CDI disabled, and op:overwrite requires the
+    # file to pre-exist — so CDI is enabled inline here rather than as a new
+    # conf.d drop-in. Content below is nv1's current containerd.toml verbatim
+    # plus the CDI block. Re-diff against the live file on every Talos upgrade.
+    - path: /etc/cri/containerd.toml
+      op: overwrite
+      permissions: 0o644
+      content: |
+        version = 3
+
+        disabled_plugins = [
+            "io.containerd.differ.v1.erofs",
+            "io.containerd.internal.v1.tracing",
+            "io.containerd.snapshotter.v1.blockfile",
+            "io.containerd.snapshotter.v1.erofs",
+            "io.containerd.ttrpc.v1.otelttrpc",
+            "io.containerd.tracing.processor.v1.otlp",
+        ]
+
+        imports = [
+            "/etc/cri/conf.d/cri.toml",
+        ]
+
+        [debug]
+        level = "info"
+        format = "json"
+
+        [plugins."io.containerd.cri.v1.runtime"]
+          enable_cdi = true
+          cdi_spec_dirs = ["/var/run/cdi"]


### PR DESCRIPTION
Phase 1 of the Jetson iGPU work. See docs/superpowers/specs/2026-08-13-jetson-igpu-design.md and docs/superpowers/plans/2026-08-13-jetson-igpu.md.

- Task 8: records the nv1 CPU-only inference baseline (`docs/superpowers/plans/artifacts/2026-08-13-nv1-cpu-baseline.md`).
- Task 9: pins nv1 to Talos v1.13.0 (kernel 6.18.24, ABI-bound to the GPU extension) and adds the GPU node config — custom OE4T installer image, kernel module load order, node labels, CDI-enabled containerd. Adds an optional per-node `talosVersion` override so `talos:upgrade:all` doesn't fight the pin.
- Task 11: vendors the GPU stack (cdi-setup, device-plugin, power-mode) from schwankner/talos-jetson-orin as a new `nvidia` kustomize app, with the nodeSelector upstream omits (without it these Tegra-specific privileged pods would land on the amd64 control planes), sync-wave ordering, and digest-pinned images.

**Already executed against the live cluster** (outside this PR, per plan gating) and verified: nv1 is booted on the custom UKI (Talos v1.13.0, kernel 6.18.24-talos), `nvgpu`/`tegra_drm`/`nvmap`/`host1x` all loaded, `/dev/dri/renderD128` exists, CDI enabled in containerd. This PR is the config catch-up for that live state.