### PR TITLE
feat(ollama): run on the Jetson iGPU instead of Intel i915

### DIFF
--- a/cluster/apps/ai/ollama/app-config.yaml
+++ b/cluster/apps/ai/ollama/app-config.yaml
@@ -1,4 +1,4 @@
-- enabled: "false"
+- enabled: "true"
   namespace: ollama
   syncPolicy:
     enabled: true

--- a/cluster/apps/ai/ollama/values.yaml
+++ b/cluster/apps/ai/ollama/values.yaml
@@ -1,6 +1,6 @@
 ollama:
   image:
-    tag: "0.20.5" # >=0.20.5 for the JetPack 6 CUDA backend (upstream Bug 19)
+    tag: "0.20.5@sha256:8ab27f32210327a04fb98f6e53fba5d19a9d632777455389d48724028434a9f0" # >=0.20.5 for the JetPack 6 CUDA backend (upstream Bug 19)
   ollama:
     models:
       pull:

--- a/cluster/apps/ai/ollama/values.yaml
+++ b/cluster/apps/ai/ollama/values.yaml
@@ -1,12 +1,14 @@
 ollama:
+  image:
+    tag: "0.20.5" # >=0.20.5 for the JetPack 6 CUDA backend (upstream Bug 19)
   ollama:
     models:
       pull:
-        - deepcoder:14b
         - qwen3.5:9b
-        - gemma4:26b
         - nomic-embed-text
   extraEnv:
+    - name: JETSON_JETPACK
+      value: "6"
     - name: OLLAMA_KV_CACHE_TYPE
       value: "q4_0"
     - name: OLLAMA_NUM_PARALLEL
@@ -17,20 +19,25 @@ ollama:
       value: "1"
     - name: OLLAMA_CONTEXT_LENGTH
       value: "16384"
-    - name: OLLAMA_VULKAN
-      value: "1"
+  nodeSelector:
+    accelerator: jetson-orin
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Equal
+      value: present
+      effect: NoSchedule
   service:
     type: ClusterIP
   ingress:
     enabled: false
   persistentVolume:
     enabled: true
-    size: "40Gi"
+    size: "20Gi"
   resources:
     limits:
-      gpu.intel.com/i915: 1
-      memory: 16Gi
+      nvidia.com/gpu: 1
+      memory: 13Gi
     requests:
-      gpu.intel.com/i915: 1
+      nvidia.com/gpu: 1
       cpu: 100m
       memory: 8Gi


### PR DESCRIPTION
Phase 1 Task 13 of the Jetson iGPU work. See docs/superpowers/specs/2026-08-13-jetson-igpu-design.md and docs/superpowers/plans/2026-08-13-jetson-igpu.md.

- Repoints ollama at nv1 (`nodeSelector: accelerator: jetson-orin`, `nvidia.com/gpu` toleration/resource) instead of the Intel i915 iGPU.
- Drops `gemma4:26b` and `deepcoder:14b`, which cannot fit in nv1's 14.8Gi of memory shared between CPU and GPU.
- Lowers the memory limit from 16Gi (above nv1's allocatable, so unschedulable there) to 13Gi.
- Adds `JETSON_JETPACK=6`, which activates the `cuda_jetpack6/libggml-cuda.so` backend — without it the container silently serves on CPU while looking healthy.
- Drops `OLLAMA_VULKAN` (the Intel-specific path).

**Pre-verified against the live cluster before this PR** (Task 12 CUDA smoke test, run outside this PR per plan gating): a non-privileged CDI-injected pod on nv1 successfully initialized CUDA (JetPack6 backend, full GPU offload, no error 801/999) and ran real inference.