### PR TITLE
docs(jetson): record Phase 1 outcome and per-node talosVersion

### DIFF
--- a/docs/superpowers/specs/2026-08-13-jetson-igpu-design.md
+++ b/docs/superpowers/specs/2026-08-13-jetson-igpu-design.md
@@ -548,3 +548,58 @@ Revert `nodes/nv1.yaml` to the factory installer image, `talosctl upgrade`, and
 set the nvidia app `enabled: "false"`. nv1 returns to its current state: an
 idle, tainted arm64 node. The taint rename and toleration changes are
 independent of the GPU work and can be kept or reverted separately.
+
+## Outcome (2026-08-13)
+
+Both phases executed and all eight gate checks passed. Summary:
+
+| #   | Check              | Result                                                        |
+| --- | ------------------ | ------------------------------------------------------------- |
+| 1   | Talos version/boot | v1.13.0, kernel `6.18.24-talos`, node `Ready`                 |
+| 2   | `nvgpu` loaded     | pass — alongside `host1x`, `tegra_drm`, `nvmap`               |
+| 3   | `/dev/dri`         | `renderD128` present                                          |
+| 4   | CDI in containerd  | `enable_cdi = true` present, customization drop-in intact     |
+| 5   | CDI spec written   | `/var/run/cdi/nvidia-jetson.yaml`, 15 device nodes            |
+| 6   | GPU advertised     | `nvidia.com/gpu: "1"` allocatable                             |
+| 7   | CUDA smoke test    | pass — JetPack6 backend, no error 801/999, non-privileged pod |
+| 8   | ollama tok/s       | **2.75x** eval rate, **12.36x** prompt eval rate — see below  |
+
+Full CPU/GPU figures: `docs/superpowers/plans/artifacts/2026-08-13-nv1-cpu-baseline.md`.
+`qwen3.5:9b`, `--think=false`, same prompt both runs: CPU eval rate 3.21
+tok/s → GPU eval rate 8.84 tok/s (2.75x, clears the required >=2x).
+
+**Go/no-go on Phase 2: GO.** The measured ratio comfortably clears the 2x
+threshold this design set as the bar for justifying a bespoke off-cluster
+Talos build. Phase 2 (forking upstream, building on GitHub Actions runners,
+publishing a self-hosted installer image) is worth designing as a follow-up.
+
+### Deviation from design: Talos cannot re-taint an already-registered node
+
+Phase 0 Task 4 assumed Talos would apply the renamed `nvidia.com/gpu` taint
+to nv1 via its ordinary machine-config reconciliation, the same way it had
+apparently applied the original `nv` taint. That assumption was wrong for an
+**already-registered** node: Kubernetes' `NodeRestriction` admission
+controller only allows a kubelet to set `.spec.taints` on its own Node object
+at initial registration (a `CREATE`); once the Node exists, any later
+`UPDATE` to its own taints is rejected, regardless of how the change was
+sourced. `talosctl dmesg` showed `k8s.NodeApplyController` retrying and
+failing every ~15s with `"nv1" is forbidden: node "nv1" is not allowed to
+modify taints`, even though `talosctl get nodetaintspecs` showed Talos had
+already computed the correct desired state internally.
+
+**Resolution:** the taint was added by hand (`kubectl taint nodes nv1
+nvidia.com/gpu=present:NoSchedule`, run with cluster-admin credentials, which
+are not subject to `NodeRestriction`). Re-running `task talos:apply` afterward
+confirmed no further drift: once the live taint matched Talos's
+`NodeTaintSpec`, the controller found nothing to patch and the error loop
+stopped, and `talos.dev/owned-taints` was written correctly. Task 5's removal
+of the orphaned `nv` taint was unaffected — it was already a manual `kubectl
+taint ... nv-` command, independent of Talos ownership.
+
+**Implication for future taint changes on already-registered nodes:** this is
+not a one-off fluke of this cluster; it is Kubernetes' documented
+`NodeRestriction` behavior, so it will recur for any future taint rename or
+addition on a node that already exists. A `.plans/TODO.md` item tracks
+investigating whether Talos has an official supported path around this, or
+whether a small skill documenting the manual-taint-then-reapply-to-confirm
+procedure is the right long-term fix.

--- a/provision/talos/README.md
+++ b/provision/talos/README.md
@@ -64,6 +64,33 @@ kustomize build cluster/apps/core/argocd | argocd-secret-replacer sops -f cluste
 3. Run `task talos:generate`
 4. For non-standard config (different disk, sysctls), add extra merge patch keys to `nodes/<name>.yaml`
 
+### Pinning a node to a non-default Talos version
+
+`nodes.yaml` supports an optional per-node `talosVersion` key, e.g.:
+
+```yaml
+nodes:
+  - name: nv1
+    ip: 192.168.48.5
+    type: worker
+    talosVersion: v1.13.0
+```
+
+When set, `task talos:upgrade N=<name>` (and therefore `task
+talos:upgrade:all`) checks that node's installed version against
+`talosVersion` instead of the global `TALOS_VERSION` in
+`.taskfiles/talos/Taskfile.yaml`. Without this, a pinned node would look
+"out of date" against the global version on every run and get reinstalled
+every time `upgrade:all` executes.
+
+Use this only when the node needs a version the fleet default doesn't carry —
+for example nv1 is pinned because its GPU kernel extension is ABI-bound to a
+specific kernel build shipped only in that Talos version's custom installer
+image (see `docs/superpowers/specs/2026-08-13-jetson-igpu-design.md`).
+Removing the pin requires the node to already be compatible with (or ready to
+move to) the global `TALOS_VERSION` — never remove it as a way to force an
+upgrade without first confirming the new version has a matching installer.
+
 ## Secrets
 
 All secrets use `TALHELPER_*` environment variables populated from Bitwarden via `.envrc`.


### PR DESCRIPTION
Task 14 of the Jetson iGPU work. Documents Phase 1's completion:

- Adds an `## Outcome` section to `docs/superpowers/specs/2026-08-13-jetson-igpu-design.md`: all 8 gate check results, the GO decision on Phase 2, and a writeup of the NodeRestriction taint deviation discovered in Phase 0 Task 4 (Talos cannot re-taint an already-registered node — only at initial registration).
- Documents the per-node `talosVersion` override convention in `provision/talos/README.md`.

This completes Phase 1 of docs/superpowers/plans/2026-08-13-jetson-igpu.md.