### PR TITLE
chore(memory): record Talos taint NodeRestriction behaviour

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -26,3 +26,4 @@
 - [QNAP QuObjects + barman-cloud caveat](reference_qnap_s3_barman_caveat.md) — boto3 ≥1.34 checksum fix required; set AWS_REQUEST_CHECKSUM_CALCULATION=when_required on all CNPG ObjectStores
 - [App removal procedure](reference_app_removal_procedure.md) — deleting the app dir never auto-prunes; manual `kubectl delete application` + separate PVC check required
 - [Ceph alert job scoping gotcha](reference_ceph_alert_job_scoping.md) — Ceph-mixin PrometheusRules lack job filters, can false-positive on non-cluster targets (router); fix via prometheusRuleOverrides
+- [Talos taints need manual kubectl on registered nodes](reference_talos_taint_noderestriction.md) — NodeRestriction blocks kubelet taint changes post-registration; one-time manual taint, then Talos adopts it

--- a/.claude/memory/reference_talos_taint_noderestriction.md
+++ b/.claude/memory/reference_talos_taint_noderestriction.md
@@ -1,0 +1,52 @@
+---
+name: reference-talos-taint-noderestriction
+description: "Talos cannot add or change a node taint on an already-registered node — NodeRestriction blocks it; a one-time manual kubectl taint is required, after which Talos adopts and maintains it"
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 912ddcce-2b51-46ef-a4eb-4ec3f8a7515d
+  modified: 2026-08-13T11:40:51.597Z
+---
+
+Changing `machine.nodeTaints` in Talos config does **not** take effect on a node
+that is already registered in the cluster. Verified on nv1 during the Jetson
+iGPU work (2026-08-13).
+
+**Why:** the apiserver runs with `--enable-admission-plugins=NodeRestriction`.
+Talos's `NodeApplyController` acts with the kubelet's credentials, and
+NodeRestriction only permits a kubelet to set taints **at registration time**.
+Any later add or change is rejected. `NodeTaintSpec` will show the desired
+taint while `Node.spec.taints` silently disagrees, with no loud error.
+
+**A second, independent blocker** (`ApplyTaints` in
+`internal/app/machined/pkg/controllers/k8s/node_apply.go`): Talos matches taints
+by **key** and tracks ownership in the `talos.dev/owned-taints` annotation. A
+taint whose key exists but is *not owned* and whose value/effect differ from the
+spec is skipped permanently (`"skipping taint update, taint is not owned"`). The
+removal pass only drops taints Talos owns, so an unowned stale taint never goes
+away on its own.
+
+**Fix — one-time, using admin credentials, not the kubelet's:**
+
+```sh
+kubectl taint nodes <node> <key>=<value>:<effect>   # add the new one
+kubectl taint nodes <node> <oldkey>-                # remove any stale one
+```
+
+Afterwards Talos hits the "not owned, but value and effect already equal the
+spec" branch, **adopts** the taint into `talos.dev/owned-taints`, and maintains
+it from then on. So this is bootstrap friction, not ongoing drift — do not plan
+recurring manual intervention.
+
+**Planning implications:**
+
+- Widen tolerations to cover both old and new taint *before* renaming, then
+  narrow afterwards. `NoSchedule` does not evict running pods, but a pod that
+  restarts mid-transition would be unschedulable.
+- Verify with `kubectl get node <n> -o jsonpath='{.spec.taints}'` and the
+  `talos.dev/owned-taints` annotation. Never assume the config was applied.
+- A fresh node registering with the config in place needs none of this.
+
+Same shape as [[feedback-deployment-strategy-patch]]: a live-object `kubectl`
+action is required before the declarative source of truth can take over.
+Related: [[feedback-talosctl-config]], [[feedback-cluster-access-rules]].


### PR DESCRIPTION
Captures a finding from the nv1 Jetson iGPU work so it is not rediscovered.

**The behaviour:** changing `machine.nodeTaints` in Talos config does nothing on a node that is already registered. The apiserver runs `--enable-admission-plugins=NodeRestriction`, and Talos's `NodeApplyController` acts with kubelet credentials — a kubelet may only set taints at registration time. `NodeTaintSpec` shows the desired taint while `Node.spec.taints` silently disagrees, with no loud error.

**A second, independent blocker:** `ApplyTaints` matches taints by key and tracks ownership in `talos.dev/owned-taints`. A taint whose key exists but is not owned, with a differing value, is skipped permanently. The removal pass only drops taints Talos owns, so a stale unowned taint never clears itself.

**The fix is one-time, not recurring:** `kubectl taint` with admin credentials creates it, after which Talos hits its "not owned, but value and effect already match spec" branch, adopts the taint, and maintains it from then on.

This bit during both Phase 0 and Phase 1 of the Jetson work (#4894–#4899).

Docs only — no cluster or manifest changes.