### PR TITLE
chore(renovate): pin Jetson cdi-setup to Ubuntu 22.04

### DIFF
--- a/.github/renovate/allowedVersions.json5
+++ b/.github/renovate/allowedVersions.json5
@@ -1,35 +1,48 @@
 {
-  "packageRules": [
+  packageRules: [
     {
-      "description": "Lock version because they changed versioning",
-      "matchDatasources": ["docker"],
-      "allowedVersions": "<1",
-      "matchPackageNames": ["ghcr.io/linuxserver/calibre-web"]
+      description: "Lock version because they changed versioning",
+      matchDatasources: ["docker"],
+      allowedVersions: "<1",
+      matchPackageNames: ["ghcr.io/linuxserver/calibre-web"],
     },
     {
-      "description": "Lock version because they changed versioning",
-      "matchDatasources": ["docker"],
-      "allowedVersions": "/^[0-9]{1,3}\\.[0-9]+\\.[0-9]+.*$/",
-      "matchPackageNames": ["ghcr.io/linuxserver/jellyfin"]
+      description: "Lock version because they changed versioning",
+      matchDatasources: ["docker"],
+      allowedVersions: "/^[0-9]{1,3}\\.[0-9]+\\.[0-9]+.*$/",
+      matchPackageNames: ["ghcr.io/linuxserver/jellyfin"],
     },
     {
-      "description": "Lock to MySQL 8.x — AzerothCore does not support MySQL 9+",
-      "matchDatasources": ["docker"],
-      "allowedVersions": "<9",
-      "matchPackageNames": ["mysql"],
-      "matchFileNames": ["cluster/apps/games/wow/**"]
+      description: "Lock to MySQL 8.x — AzerothCore does not support MySQL 9+",
+      matchDatasources: ["docker"],
+      allowedVersions: "<9",
+      matchPackageNames: ["mysql"],
+      matchFileNames: ["cluster/apps/games/wow/**"],
     },
     {
-      "description": "Lock version to cluster version",
-      "matchDatasources": ["docker", "github-releases"],
-      "allowedVersions": "<=1.35",
-      "matchPackageNames": [
+      // The Jetson cdi-setup init container extracts NVIDIA L4T r36.5 .deb
+      // packages (nvidia-l4t-core / -cuda / -3d-core) and hands the resulting
+      // libraries to every GPU pod via CDI. Those packages are built for
+      // Ubuntu 22.04 (jammy) — that is what JetPack 6 targets — so a newer
+      // base risks a glibc/toolchain mismatch in the CUDA userspace.
+      // Unpin only together with a JetPack release that targets a newer LTS.
+      description: "Lock to Ubuntu 22.04 — JetPack 6 / L4T r36.5 packages are built for jammy",
+      matchDatasources: ["docker"],
+      allowedVersions: "/^22\\.04$/",
+      matchPackageNames: ["ubuntu"],
+      matchFileNames: ["cluster/apps/system/nvidia/**"],
+    },
+    {
+      description: "Lock version to cluster version",
+      matchDatasources: ["docker", "github-releases"],
+      allowedVersions: "<=1.35",
+      matchPackageNames: [
         "alpine/k8s",
         "kubernetes/kubernetes",
         "registry.k8s.io/kubectl",
         "siderolabs/kubelet",
-        "ghcr.io/siderolabs/kubelet"
-      ]
-    }
-  ]
+        "ghcr.io/siderolabs/kubelet",
+      ],
+    },
+  ],
 }


### PR DESCRIPTION
Stops Renovate regenerating the ubuntu major bump against the Jetson GPU stack. #4904 was closed manually; without this rule it comes back.

## Why

`cluster/apps/system/nvidia/resources/cdi-setup.yaml` runs an `ubuntu` init container that downloads and extracts NVIDIA L4T r36.5 packages:

```sh
BASE="https://repo.download.nvidia.com/jetson/t234/pool/main/n"
curl ... nvidia-l4t-core_${VER}_arm64.deb
dpkg-deb -x ...
```

The extracted CUDA userspace libraries are injected into **every GPU pod** via CDI. Those packages are built for Ubuntu 22.04 (jammy) — what JetPack 6 targets — so bumping the base to 26.04 risks a glibc/toolchain mismatch on the path ollama's CUDA backend depends on. Renovate itself flagged the PR breaking (`!`).

## The rule

```json5
{
  "description": "Lock to Ubuntu 22.04 — JetPack 6 / L4T r36.5 packages are built for jammy",
  "matchDatasources": ["docker"],
  "allowedVersions": "/^22\\.04$/",
  "matchPackageNames": ["ubuntu"],
  "matchFileNames": ["cluster/apps/system/nvidia/**"]
}
```

Follows the existing MySQL 8.x lock in the same file (version ceiling + `matchFileNames` scoping).

## Verified

- JSON5 parses; rule resolves as intended
- Regex allows `22.04`; blocks `24.04`, `26.04`, `26`, `latest`, `jammy`
- Glob matches `cluster/apps/system/nvidia/resources/cdi-setup.yaml`
- `ubuntu` is referenced nowhere else under `cluster/`, so nothing else is affected
- Constrains **versions only** — digest refreshes for the 22.04 tag still flow, so security patches are not blocked

Unpin only alongside a JetPack release targeting a newer LTS; the reasoning is in a comment above the rule.