### PR TITLE
feat(nv1): use our own Jetson installer image

### DIFF
--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -216,13 +216,16 @@ tasks:
         sh: yq ea '[.machine.install.image].[0]' < "{{.FILE}}"
       FORCE: "{{ .FORCE | default false }}"
       # Derived from the install image tag, which already encodes the version —
-      # one source of truth instead of two that can desync. Nodes on the stock
-      # factory installer do not match and fall back to the global version.
-      # NB: `sed -n …p` exits 0 even when nothing matches, so the fallback must
-      # test the captured value rather than chain off the exit status.
+      # one source of truth instead of two that can desync. Read from the
+      # committed nodes/*.yaml, never from clusterconfig/: those are generated
+      # and gitignored, so on a fresh clone they are absent and this would
+      # silently fall back to the global version instead of failing.
+      # Nodes on the stock factory installer have no install.image override and
+      # correctly fall back. NB: `sed -n …p` exits 0 even when nothing matches,
+      # so the fallback must test the captured value, not the exit status.
       NODE_TALOS_VERSION:
         sh: |
-          v=$(yq '.machine.install.image' {{.TALOS_DIR}}/clusterconfig/home-{{.N}}.yaml \
+          v=$(yq '.machine.install.image // ""' {{.TALOS_DIR}}/nodes/{{.N}}.yaml 2>/dev/null \
                 | sed -n 's|.*custom-installer:v\{0,1\}\([0-9.]*\)-.*|v\1|p')
           echo "${v:-{{ .TALOS_VERSION }}}"
     status:

--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -215,8 +215,16 @@ tasks:
       TALOS_IMAGE:
         sh: yq ea '[.machine.install.image].[0]' < "{{.FILE}}"
       FORCE: "{{ .FORCE | default false }}"
+      # Derived from the install image tag, which already encodes the version —
+      # one source of truth instead of two that can desync. Nodes on the stock
+      # factory installer do not match and fall back to the global version.
+      # NB: `sed -n …p` exits 0 even when nothing matches, so the fallback must
+      # test the captured value rather than chain off the exit status.
       NODE_TALOS_VERSION:
-        sh: yq '.nodes[] | select(.name == "{{ .N }}") | .talosVersion // "{{ .TALOS_VERSION }}"' < {{.TALOS_DIR}}/nodes.yaml
+        sh: |
+          v=$(yq '.machine.install.image' {{.TALOS_DIR}}/clusterconfig/home-{{.N}}.yaml \
+                | sed -n 's|.*custom-installer:v\{0,1\}\([0-9.]*\)-.*|v\1|p')
+          echo "${v:-{{ .TALOS_VERSION }}}"
     status:
       - $([ "{{ .FORCE }}" = "false" ] && talosctl version --nodes {{ .NODE }} --short | grep -q 'Tag.*{{ .NODE_TALOS_VERSION }}' || return 1)
     cmds:

--- a/provision/talos/nodes.yaml
+++ b/provision/talos/nodes.yaml
@@ -11,6 +11,3 @@ nodes:
   - name: nv1
     ip: 192.168.48.5
     type: worker
-    # Pinned: the GPU extension is ABI-bound to kernel 6.18.24.
-    # Remove this line only together with a rebuilt installer image.
-    talosVersion: v1.13.0

--- a/provision/talos/nodes/nv1.yaml
+++ b/provision/talos/nodes/nv1.yaml
@@ -11,7 +11,7 @@ machine:
             gateway: 192.168.50.1
 
   install:
-    image: ghcr.io/schwankner/custom-installer:v1.13.0-6.18.24-nvgpu5.11.1-drm-noshim
+    image: ghcr.io/mmalyska/custom-installer:v1.13.8-6.18.42-nvgpu5.11.1-drm-noshim
 
   kernel:
     modules:


### PR DESCRIPTION
Moves nv1 off the upstream-published v1.13.0 image and onto
ghcr.io/mmalyska/custom-installer, built from our fork. Also collapses
the talosVersion key into the install image tag, which already contains
the version - one source of truth instead of two that can desync.

The image is v1.13.8-6.18.42, not the v1.13.8-6.18.24 originally planned:
the imager ships kernel 6.18.42 and refuses to assemble a UKI against
extensions built for 6.18.24, so PKGS_COMMIT had to move with
TALOS_VERSION. nv1 therefore reaches full kernel parity with the mc
nodes rather than staying pinned at 6.18.24.
