### PR TITLE
fix(renovate): disable platformAutomerge for weekly-scheduled digest groups

### DIFF
--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -61,11 +61,12 @@
       "separateMinorPatch": true
     },
     {
-      "description": "Hermes agent — weekly digest updates only (frequent main builds cause excessive pod restarts)",
+      "description": "Hermes agent — weekly digest updates only (frequent main builds cause excessive pod restarts). platformAutomerge must be disabled here: GitHub's native automerge enqueues at PR-creation time and ignores automergeSchedule entirely, which silently defeated this rule before.",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["nousresearch/hermes-agent"],
       "matchUpdateTypes": ["digest"],
-      "automergeSchedule": ["before 5am on monday"]
+      "automergeSchedule": ["before 5am on monday"],
+      "platformAutomerge": false
     },
     {
       "description": "AzerothCore WoW server images",
@@ -78,7 +79,8 @@
       ],
       "groupName": "azerothcore",
       "group": {"commitMessageTopic": "{{{groupName}}} group"},
-      "automergeSchedule": ["before 5am on monday"]
+      "automergeSchedule": ["before 5am on monday"],
+      "platformAutomerge": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- The hermes-agent and azerothcore digest packageRules in `.github/renovate/groups.json5` set `automergeSchedule: ["before 5am on monday"]` intending weekly-only automerge, but Renovate defaults `platformAutomerge` to `true`. With platform automerge enabled, Renovate hands the PR to GitHub's native auto-merge at PR-creation time, and GitHub merges as soon as CI passes — completely ignoring `automergeSchedule`.
- This is a documented Renovate limitation: "When `platformAutomerge` is enabled, Renovate enqueues the platform PR automerge at time of creation, so the schedule specified in `automergeSchedule` cannot be followed."
- Git history confirms this: a prior attempt at this same fix (#4364, 2026-07-01) added `automergeSchedule` but hermes-agent digest PRs kept auto-merging multiple times per day, every day of the week, ever since.
- Fix: add `platformAutomerge: false` to both rules so Renovate performs the merge itself, which does honor `automergeSchedule`.

## Test plan
- [ ] Confirm `.github/renovate/groups.json5` is valid JSON5 (parsed successfully locally)
- [ ] After merge, confirm hermes-agent/azerothcore digest PRs open as usual but only automerge in the Monday pre-5am window going forward