### PR TITLE
feat(hermes-agent): track versioned release tags instead of rolling :main

### DIFF
--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -61,10 +61,11 @@
       "separateMinorPatch": true
     },
     {
-      "description": "Hermes agent — weekly digest updates only (frequent main builds cause excessive pod restarts). platformAutomerge must be disabled here: GitHub's native automerge enqueues at PR-creation time and ignores automergeSchedule entirely, which silently defeated this rule before.",
+      "description": "Hermes agent — track curated v2026.x.x release tags (not the noisy rolling :main tag) and cap automerge to weekly. versioning: loose because tags are CalVer with an occasional 4th hotfix component (e.g. v2026.7.7.2) that default docker/semver versioning sorts incorrectly. platformAutomerge must be disabled here: GitHub's native automerge enqueues at PR-creation time and ignores automergeSchedule entirely, which silently defeated this rule before.",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["nousresearch/hermes-agent"],
-      "matchUpdateTypes": ["digest"],
+      "versioning": "loose",
+      "matchUpdateTypes": ["patch", "minor", "digest"],
       "automergeSchedule": ["before 5am on monday"],
       "platformAutomerge": false
     },

--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -61,11 +61,12 @@
       "separateMinorPatch": true
     },
     {
-      "description": "Hermes agent — weekly digest updates only (frequent main builds cause excessive pod restarts)",
+      "description": "Hermes agent — weekly digest updates only (frequent main builds cause excessive pod restarts). platformAutomerge must be disabled here: GitHub's native automerge enqueues at PR-creation time and ignores automergeSchedule entirely, which silently defeated this rule before.",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["nousresearch/hermes-agent"],
       "matchUpdateTypes": ["digest"],
-      "automergeSchedule": ["before 5am on monday"]
+      "automergeSchedule": ["before 5am on monday"],
+      "platformAutomerge": false
     },
     {
       "description": "AzerothCore WoW server images",
@@ -78,7 +79,8 @@
       ],
       "groupName": "azerothcore",
       "group": {"commitMessageTopic": "{{{groupName}}} group"},
-      "automergeSchedule": ["before 5am on monday"]
+      "automergeSchedule": ["before 5am on monday"],
+      "platformAutomerge": false
     }
   ]
 }

--- a/cluster/apps/ai/hermes-agent/values.yaml
+++ b/cluster/apps/ai/hermes-agent/values.yaml
@@ -2,7 +2,7 @@ hermes:
   replicas: 1
   image:
     repository: nousresearch/hermes-agent
-    tag: "main@sha256:3006d820d53f018d87d05a1a7d28e3ed5b07e78aadb272cb132f329198c8132d"
+    tag: "v2026.8.16@sha256:f8f548d87d16634d1ad9e3777280f3f577ba2358703f04e18e74007ffd3621bf"
   resources:
     requests:
       cpu: 200m


### PR DESCRIPTION
## Summary
Stacked on #4991 — merge that first, this PR's diff will shrink to just the two files below once it lands.

- hermes-agent's `:main` Docker tag is rebuilt on every push to the upstream repo's `main` branch. I checked upstream commit history (`NousResearch/hermes-agent`): it went from ~1 commit every few days to 30-50+ commits/day starting early July and intensifying through August (looks like a self-improving coding agent iterating on itself). Every one of those commits produces a new `:main` digest.
- Upstream also publishes curated `v2026.x.x` release tags at a much calmer cadence (every few days to weeks) — this switches the deployment to track that tag family instead.
- Pinned `cluster/apps/ai/hermes-agent/values.yaml` to `v2026.8.16` (current latest release, matches the digest reported by Docker Hub for that tag).
- Updated the Renovate rule in `.github/renovate/groups.json5`:
  - Added `"versioning": "loose"`. Verified locally against Renovate's actual versioning modules (installed `renovate` from npm, ran its `docker`/`semver-coerced`/`loose` version comparators against the real tag list) — the tags are CalVer (`v<year>.<month>.<day>`) but occasionally carry a 4th "hotfix" component (e.g. `v2026.7.7.2`, `v2026.5.29.2`). Both `docker` and `semver-coerced` versioning incorrectly treat those hotfix tags as *older* than their 3-part parent (`isGreaterThan` returns false), which would make Renovate skip them. `loose` versioning sorts and classifies all 21 real historical tags correctly.
  - Changed `matchUpdateTypes` from `["digest"]` to `["patch", "minor", "digest"]`, since updates will now mostly show up as version bumps rather than bare digest changes. Major (year rollover) is intentionally excluded, matching the repo's existing "never automerge major" convention.

## Test plan
- [x] `helm template hermes-agent . -f values.yaml` renders cleanly with the new pinned tag
- [ ] After merge, confirm Renovate opens a PR for the next `v2026.x.x` release (not digest-only) and it automerges only in the Monday pre-5am window