### PR TITLE
chore: cut write volume reaching the Ceph OSD SSDs

### DIFF
--- a/charts/pgsql-cnpg/Chart.yaml
+++ b/charts/pgsql-cnpg/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v2
 name: pgsql-cnpg
 type: application
-version: 1.4.0
+version: 1.5.0

--- a/charts/pgsql-cnpg/templates/cnpg.yaml
+++ b/charts/pgsql-cnpg/templates/cnpg.yaml
@@ -23,7 +23,14 @@ spec:
   {{- end }}
   postgresql:
     parameters:
-      pgaudit.log: "all, -misc"
+      # "ddl, write" rather than "all, -misc". "all" audited every statement
+      # including every SELECT, on every cluster using this chart. Those audit
+      # lines go to stdout -> Alloy -> Loki, and Loki's own storage is a Ceph
+      # RBD volume — so verbose auditing was amplifying writes onto the same
+      # wearing MX500 drives twice over. DDL and write statements are the ones
+      # with forensic value; reads were volume without much benefit here.
+      # Override per app if a specific database genuinely needs read auditing.
+      pgaudit.log: "ddl, write"
       pgaudit.log_catalog: "off"
       pgaudit.log_parameter: "on"
       pgaudit.log_relation: "on"

--- a/charts/pgsql-cnpg/values.yaml
+++ b/charts/pgsql-cnpg/values.yaml
@@ -31,6 +31,14 @@ instanceSidecarConfiguration:
 postgresql:
   parameters:
     archive_timeout: "30min"
+    # WAL compression, off by default in PostgreSQL. Every WAL byte is
+    # written to a Ceph RBD volume and replicated 3x onto consumer-grade
+    # MX500 SSDs that are already at 62-70% rated life. Full-page writes
+    # (emitted after each checkpoint for every touched page) compress
+    # particularly well, so this cuts real bytes written for a little CPU.
+    # Safe and long-established — it compresses the WAL record payload and
+    # changes nothing about durability or replication semantics.
+    wal_compression: "on"
 # retentionPolicy: "10d"
 # objectStore:
 #   destinationPath: "s3://bucket/cnpg/<name>"

--- a/cluster/apps/ai/coder/Chart.yaml
+++ b/cluster/apps/ai/coder/Chart.yaml
@@ -7,5 +7,5 @@ dependencies:
     version: 2.37.1
     repository: https://helm.coder.com/v2
   - name: pgsql-cnpg
-    version: 1.4.0
+    version: 1.5.0
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/ai/honcho/Chart.yaml
+++ b/cluster/apps/ai/honcho/Chart.yaml
@@ -5,5 +5,5 @@ type: application
 version: 1.0.0
 dependencies:
   - name: pgsql-cnpg
-    version: 1.4.0
+    version: 1.5.0
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/ai/litellm/Chart.yaml
+++ b/cluster/apps/ai/litellm/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
     version: 1.100.0
     repository: oci://ghcr.io/berriai
   - name: pgsql-cnpg
-    version: 1.4.0
+    version: 1.5.0
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/default/bookorbit/Chart.yaml
+++ b/cluster/apps/default/bookorbit/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
     version: 5.1.0
     repository: https://bjw-s-labs.github.io/helm-charts
   - name: pgsql-cnpg
-    version: 1.4.0
+    version: 1.5.0
     repository: file://../../../../charts/pgsql-cnpg/
   - name: volsync
     version: 1.0.0

--- a/cluster/apps/default/gitea/Chart.yaml
+++ b/cluster/apps/default/gitea/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 12.7.0
     repository: https://dl.gitea.io/charts/
   - name: pgsql-cnpg
-    version: 1.4.0
+    version: 1.5.0
     repository: file://../../../../charts/pgsql-cnpg/
   - name: dragonfly
     version: 1.0.1

--- a/cluster/apps/default/harbor/Chart.yaml
+++ b/cluster/apps/default/harbor/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
     version: 1.19.2
     repository: https://helm.goharbor.io
   - name: pgsql-cnpg
-    version: 1.4.0
+    version: 1.5.0
     repository: file://../../../../charts/pgsql-cnpg/
   - name: dragonfly
     version: 1.0.1

--- a/cluster/apps/home-automation/home-assistant/Chart.yaml
+++ b/cluster/apps/home-automation/home-assistant/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 5.1.0
     repository: https://bjw-s-labs.github.io/helm-charts
   - name: pgsql-cnpg
-    version: 1.4.0
+    version: 1.5.0
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/system/keycloak/Chart.yaml
+++ b/cluster/apps/system/keycloak/Chart.yaml
@@ -6,5 +6,5 @@ version: 2.6.0
 appVersion: "17.0.1"
 dependencies:
   - name: pgsql-cnpg
-    version: 1.4.0
+    version: 1.5.0
     repository: file://../../../../charts/pgsql-cnpg/

--- a/cluster/apps/system/prometheus-stack/values.yaml
+++ b/cluster/apps/system/prometheus-stack/values.yaml
@@ -10,6 +10,46 @@ kube-prometheus-stack:
     enabled: false
   kubeScheduler:
     enabled: true
+  kubeApiServer:
+    serviceMonitor:
+      # job="apiserver" alone accounted for 129,633 of 275,451 active series
+      # (47%), almost entirely histogram buckets. Each series is sampled
+      # forever and written to Ceph, so cardinality here translates directly
+      # into wear on the MX500 OSD drives.
+      #
+      # Dropped below are buckets no bundled rule or dashboard consumes,
+      # ~42k series between them. Deliberately NOT dropped, despite being the
+      # largest of all: apiserver_request_duration_seconds_bucket,
+      # apiserver_request_sli_duration_seconds_bucket and
+      # etcd_request_duration_seconds_bucket — the kube-apiserver SLO and
+      # etcd alert rules are built on them, and dropping them would silently
+      # break alerting rather than just saving space.
+      metricRelabelings:
+        # First rule is the chart's own default, restated verbatim. Setting
+        # metricRelabelings replaces the default list rather than appending to
+        # it, so omitting this would silently re-admit the noisy le buckets on
+        # the four largest histograms — increasing cardinality, not reducing
+        # it. Keep it first, and re-check it on chart upgrades.
+        - action: drop
+          regex: (etcd_request|apiserver_request_slo|apiserver_request_sli|apiserver_request)_duration_seconds_bucket;(0\.15|0\.2|0\.3|0\.35|0\.4|0\.45|0\.6|0\.7|0\.8|0\.9|1\.25|1\.5|1\.75|2|3|3\.5|4|4\.5|6|7|8|9|15|20|40|45|50)(\.0)?
+          sourceLabels:
+            - __name__
+            - le
+        - sourceLabels: [__name__]
+          action: drop
+          regex: apiserver_request_body_size_bytes_bucket
+        - sourceLabels: [__name__]
+          action: drop
+          regex: apiserver_watch_cache_read_wait_seconds_bucket
+        - sourceLabels: [__name__]
+          action: drop
+          regex: apiserver_watch_list_duration_seconds_bucket
+        - sourceLabels: [__name__]
+          action: drop
+          regex: apiserver_response_sizes_bucket
+        - sourceLabels: [__name__]
+          action: drop
+          regex: apiserver_watch_events_sizes_bucket
   grafana:
     revisionHistoryLimit: 3
     grafana.ini:
@@ -208,6 +248,14 @@ kube-prometheus-stack:
     revisionHistoryLimit: 3
   prometheus:
     prometheusSpec:
+      # 60s rather than the 30s default. Every sample written lands on the
+      # Ceph RBD volume and, at 3x replication, on all three consumer-grade
+      # MX500 OSD drives. Those drives are at 62-70% rated life after ~4
+      # years with only ~27 TB of host writes each — they age on NAND P/E
+      # cycles, so halving the sample rate directly slows that curve.
+      # 60s resolution is ample for this cluster; raise it back if a
+      # short-lived spike ever needs to be caught.
+      scrapeInterval: 60s
       retention: 10d
       retentionSize: 20GiB
       storageSpec:


### PR DESCRIPTION
## Why

The three MX500 OSD drives are at **62-70% of rated life** after ~4 years, on only
**~27 TB of host writes** each. They age on NAND P/E cycles, not host bytes:
~850 average block erases against 27 TB implies a **write amplification factor
around 15×** — inherent to Ceph's small random writes, BlueStore metadata and
RocksDB compaction.

The BlueStore side is already tuned as far as it goes:

```
bluestore_min_alloc_size_ssd       4096   minimal space amplification
bluestore_prefer_deferred_size_ssd    0   no SSD double-write
bluestore_cache_autotune           true
bdev_async_discard                 true
pool compression                          83 GiB -> 24 GiB (~3.5:1)
Prometheus WAL compression           on
```

So this reduces writes **at source** instead.

## Changes

**1 — Prometheus scrape interval 30s → 60s.** 275,451 active series were producing
**8,617 samples/s**. Halving the rate halves the WAL, block compaction and
everything downstream. 60s resolution is ample here.

**2 — Drop five high-cardinality apiserver histograms (~42k series).**
`job=apiserver` alone was **129,633 of 275,451** series, nearly all histogram
buckets:

| dropped | series |
|---|---|
| `apiserver_request_body_size_bytes_bucket` | 12,512 |
| `apiserver_watch_cache_read_wait_seconds_bucket` | 8,666 |
| `apiserver_watch_list_duration_seconds_bucket` | 8,604 |
| `apiserver_response_sizes_bucket` | 7,192 |
| `apiserver_watch_events_sizes_bucket` | 5,283 |

**Deliberately not dropped**, despite being the largest of all:
`apiserver_request_duration_seconds_bucket`,
`apiserver_request_sli_duration_seconds_bucket`, `etcd_request_duration_seconds_bucket`.
The bundled apiserver SLO and etcd alert rules are built on them — dropping them
would break alerting rather than just save space.

> ⚠️ `metricRelabelings` **replaces** the chart's default list rather than appending.
> The chart's own `le`-bucket drop rule is therefore restated verbatim as the first
> entry. Omitting it would have re-admitted noisy buckets on the four largest
> histograms and *increased* cardinality — the opposite of the intent. Re-check this
> on chart upgrades.

**3 — CNPG `wal_compression = on`.** All six Postgres clusters inherited
PostgreSQL's default of `off`. Full-page writes — emitted for every page touched
after a checkpoint — compress well. Cuts real WAL bytes for some CPU, with no
change to durability or replication semantics.

**4 — pgaudit `"all, -misc"` → `"ddl, write"`.** Auditing every statement including
every `SELECT` sent those lines to stdout → Alloy → Loki, whose own storage is a
Ceph RBD volume. Verbose auditing was amplifying writes onto the same wearing
drives twice over. DDL and write statements keep the forensic value; reads were
volume without much benefit. Override per app if a database genuinely needs read
auditing.

## Chart version bump

`pgsql-cnpg` is a shared local chart pinned by **eight** consumers, so it goes
`1.4.0 → 1.5.0` with all eight pins updated in the same commit — a `file://`
dependency fails to resolve on any mismatch.

## Verification

- `helm template` renders all four changes correctly; `archive_timeout: 30min` is
  preserved alongside the new `wal_compression`
- A consumer chart (`bookorbit`) resolves the bumped dependency and renders the
  new parameters
- The apiserver ServiceMonitor renders **six** relabel rules — chart default first,
  then the five additions
- yamllint +1 error, which is the verbatim upstream regex restated on one line and
  cannot be reformatted without changing it

## Expected effect

Roughly **59% less Prometheus write volume** (1 + 2 combined), plus meaningful
reductions in Postgres WAL and Loki ingest. Nothing here is destructive and every
item is independently revertible.

https://claude.ai/code/session_01E3wxhh3YfeVdDMiFubWQ1e
