### PR TITLE
fix(rook-ceph): drop the CSI publish params, StorageClass is immutable

### DIFF
--- a/cluster/apps/core/rook-ceph/cluster/values.yaml
+++ b/cluster/apps/core/rook-ceph/cluster/values.yaml
@@ -170,12 +170,16 @@ rook-ceph-cluster:
           csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
           csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
           csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
-          # This map replaces the chart's default wholesale, so the
-          # controller-publish pair has to be restated or it is silently
-          # dropped. The driver has attachRequired: true, so ControllerPublish
-          # is invoked for these volumes.
-          csi.storage.k8s.io/controller-publish-secret-name: rook-csi-rbd-provisioner
-          csi.storage.k8s.io/controller-publish-secret-namespace: rook-ceph
+          # NOTE: do not add csi.storage.k8s.io/controller-publish-secret-name
+          # or -namespace here. Overriding this map does drop the chart's
+          # defaults for them, but StorageClass.parameters is IMMUTABLE — the
+          # API server rejects any change with "updates to parameters are
+          # forbidden", which breaks ArgoCD's server-side diff and leaves this
+          # app unable to sync at all. Adding them would require deleting and
+          # recreating both StorageClasses, and ceph-block is the cluster
+          # default, so a PVC created during that window would fail. ceph-csi's
+          # ControllerPublish does not need these credentials in practice, so
+          # the parity is not worth the disruption.
           csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
           csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
           csi.storage.k8s.io/fstype: ext4
@@ -222,10 +226,8 @@ rook-ceph-cluster:
           csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
           csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
           csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
-          # See the rbd storageClass above: overriding this map drops the
-          # chart's controller-publish pair unless it is restated here.
-          csi.storage.k8s.io/controller-publish-secret-name: rook-csi-cephfs-provisioner
-          csi.storage.k8s.io/controller-publish-secret-namespace: rook-ceph
+          # See the rbd storageClass above: the controller-publish pair is
+          # deliberately absent because StorageClass.parameters is immutable.
           csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
           csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
           csi.storage.k8s.io/fstype: ext4


### PR DESCRIPTION
Fixes the sync failure introduced by #5145.

## What broke

#5145 added `csi.storage.k8s.io/controller-publish-secret-name` and `-namespace`
to both storageClass parameter maps, restoring keys the wholesale override had
dropped from the chart defaults.

That was wrong. **`StorageClass.parameters` is immutable.** The API server rejects
any change:

```
StorageClass.storage.k8s.io "ceph-filesystem" is invalid:
parameters: Forbidden: updates to parameters are forbidden.
```

which fails ArgoCD's server-side diff and leaves `rook-ceph-cluster` stuck
`Unknown`/`Degraded`, unable to sync at all — the same failure mode as the earlier
cephx `keyType` issue, arrived at from the opposite direction.

I verified the manifest rendered correctly but never checked whether the field was
mutable on a live object. Rendering correctly and applying successfully are not the
same test.

## Why revert rather than reconcile

Applying those keys would require **deleting and recreating both StorageClasses**.
`ceph-block` is the cluster default, so any PVC created during that window would
fail provisioning.

And the parity buys nothing: ceph-csi's `ControllerPublish` does not need these
credentials in practice — 144+ pods have been running on these volumes without
them throughout. #5145 itself said "nothing is broken today", which should have
been the signal not to touch an immutable field for cosmetic parity.

## Verification

Rendered parameters are now **key-for-key identical** to the live objects:

| StorageClass | rendered | live | drift |
|---|---|---|---|
| `ceph-block` | 11 params | 11 params | none |
| `ceph-filesystem` | 10 params | 10 params | none |

No parameter update remains for the API server to reject. yamllint drops 9 → 7
(the two long lines removed were the ones this PR deletes).

The comment is replaced with one recording *why* these keys must stay out, so the
apparent gap doesn't get "fixed" again later.

## Not affected

The rest of #5145 stands and is working: the cephx daemon key rotation, the dead
mgr module removal, and the MDS cache cap.

https://claude.ai/code/session_01E3wxhh3YfeVdDMiFubWQ1e
