### PR TITLE
fix(grafana): add the missing unifi dashboard provider

### DIFF
--- a/cluster/apps/system/prometheus-stack/values.yaml
+++ b/cluster/apps/system/prometheus-stack/values.yaml
@@ -110,6 +110,21 @@ kube-prometheus-stack:
             editable: false
             options:
               path: /var/lib/grafana/dashboards/ceph
+          # Every key under `dashboards:` MUST have a provider with a matching
+          # name here. The provider is what creates
+          # /var/lib/grafana/dashboards/<name>, and the chart's
+          # download_dashboards.sh init container writes into that directory.
+          # Adding a `dashboards.unifi:` block without this entry made the
+          # init container fail with "can't create .../unifi/...json:
+          # nonexistent directory", crash-looping Grafana on startup.
+          - name: "unifi"
+            orgId: 1
+            folder: "UniFi"
+            type: file
+            disableDeletion: true
+            editable: false
+            options:
+              path: /var/lib/grafana/dashboards/unifi
     dashboardsConfigMaps:
       device: "device-dashboards"
     dashboards:


### PR DESCRIPTION
Grafana is currently **down** — `Init:CrashLoopBackOff` — and this fixes it.

## Cause

#5144 added a `dashboards.unifi:` block with the five UniFi-Poller dashboards, but
no matching entry under `dashboardProviders`. The provider is what creates
`/var/lib/grafana/dashboards/<name>`, and the chart's `download_dashboards.sh` init
container writes into that directory. So the download worked and the *write* failed:

```
/etc/grafana/download_dashboards.sh: line 174: can't create
/var/lib/grafana/dashboards/unifi/unifi-client-insights.json: nonexistent directory
```

The init container exits non-zero, so the pod never reaches its main container.
Grafana was fully down, not merely missing the new dashboards — and
`prometheus-stack` shows Degraded as a result.

My mistake in #5144: I verified the dashboards rendered into the values, but not
that they had a provider to land in.

## Fix

Adds the `unifi` provider (folder "UniFi") pointing at the same path, plus a comment
recording the invariant — **every key under `dashboards:` needs a provider of the
same name**, or the init container fails hard rather than skipping that dashboard.

## Verification

Rather than eyeballing it, the render is checked by set comparison — directories the
download script writes to vs. directories the providers create:

```
dirs written by download script: ceph, default, device, grafana-dashboards-kubernetes, unifi
dirs created by providers      : ceph, default, device, grafana-dashboards-kubernetes, unifi
MISSING provider for           : none
```

yamllint unchanged (24 before and after).

https://claude.ai/code/session_01E3wxhh3YfeVdDMiFubWQ1e
