### PR TITLE
fix(nextcloud): bump pgsql-cnpg subchart to 1.5.0

### DIFF
--- a/cluster/apps/default/nextcloud/app/Chart.yaml
+++ b/cluster/apps/default/nextcloud/app/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 9.2.6
     repository: https://nextcloud.github.io/helm/
   - name: pgsql-cnpg
-    version: 1.4.0
+    version: 1.5.0
     repository: file://../../../../../charts/pgsql-cnpg/
   - name: dragonfly
     version: 1.0.1

--- a/cluster/apps/default/nextcloud/onlyoffice/Chart.yaml
+++ b/cluster/apps/default/nextcloud/onlyoffice/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
     version: 1.0.4
     repository: file://../../../../../charts/onlyoffice-documentserver/
   - name: pgsql-cnpg
-    version: 1.4.0
+    version: 1.5.0
     repository: file://../../../../../charts/pgsql-cnpg/


### PR DESCRIPTION
## Problem

`nextcloud-onlyoffice` ArgoCD app is stuck in `ComparisonError` / sync status `Unknown`:

```
`bash -c "helm dependency update"` failed exit status 1: Error: can't get a valid
version for 1 subchart(s): "pgsql-cnpg" (repository "file://.../charts/pgsql-cnpg/",
version "1.4.0"). Make sure a matching chart version exists in the repo...
```

## Root cause

PR #5148 (`f4833bd3`, "cut write volume reaching the Ceph OSD SSDs") bumped the local
chart `charts/pgsql-cnpg` from **1.4.0 → 1.5.0** and updated every consumer *except* the
two under `cluster/apps/default/nextcloud/`. A `file://` dependency can only resolve the
exact version present on disk, so the stale `1.4.0` pin fails `helm dependency update`.

- `nextcloud/onlyoffice/Chart.yaml` — broke (cache refreshed after the merge)
- `nextcloud/app/Chart.yaml` — same latent break, currently masked by a still-valid
  repo-server manifest cache; fixed here too before it surfaces

## Fix

Bump the `pgsql-cnpg` dependency to `1.5.0` in both `Chart.yaml` files, matching the
other 8 consumers. `Chart.lock` / `*.tgz` are gitignored and regenerated by ArgoCD's
CMP on render.

pgsql-cnpg 1.5.0 is config-only: `wal_compression: on` and `pgaudit.log` narrowed to
`ddl, write`. No schema or API impact.

## Verification

- `helm dependency update` now succeeds for both charts (same command ArgoCD's CMP runs)
- `helm template` renders cleanly for both
- `task lint:yaml` clean for both changed files

https://claude.ai/code/session_016qjFSFQWUR89DVipBCqp8Z