### PR TITLE
fix(argocd): stop argocd-secret tracking-id drift from ESO

### DIFF
--- a/cluster/apps/core/argocd/app-config.yaml
+++ b/cluster/apps/core/argocd/app-config.yaml
@@ -14,3 +14,9 @@
       name: argocd-secret
       jsonPointers:
         - /data/oidc.keycloak.clientSecret
+        # ESO reconciles argocd-secret (creationPolicy: Merge) and can
+        # transiently overwrite the tracking-id annotation between the ESO
+        # refresh and the next ArgoCD sync; ignore it so the app does not
+        # flap OutOfSync. ArgoCD still tracks the secret via the
+        # app.kubernetes.io/instance label.
+        - /metadata/annotations/argocd.argoproj.io~1tracking-id

--- a/cluster/apps/core/argocd/resources/argocd-oidc-externalsecret.yaml
+++ b/cluster/apps/core/argocd/resources/argocd-oidc-externalsecret.yaml
@@ -11,6 +11,15 @@ spec:
   target:
     name: argocd-secret
     creationPolicy: Merge
+    # Define template metadata explicitly so ESO does not inherit this
+    # ExternalSecret's own labels/annotations onto argocd-secret. Without
+    # this, ESO copies its argocd.argoproj.io/tracking-id onto the shared
+    # secret, clobbering ArgoCD's own tracking-id and leaving the argocd
+    # Application permanently OutOfSync on that annotation.
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata: {}
   data:
     - secretKey: oidc.keycloak.clientSecret
       remoteRef:


### PR DESCRIPTION
## Problem

The `argocd` Application is permanently `OutOfSync` after every sync. The only drifting resource is `Secret/argocd-secret`, on a single field:

```
/metadata/annotations/argocd.argoproj.io~1tracking-id
  live:    argocd:external-secrets.io/ExternalSecret:argocd/argocd-oidc-secret
  desired: argocd:/Secret:argocd/argocd-secret
```

## Root cause

Two controllers fight over that annotation:

1. **ArgoCD** manages `argocd-secret` (the empty `Secret` shell from the upstream `manifests/cluster-install` base). With `annotation+label` tracking it stamps `argocd.argoproj.io/tracking-id: argocd:/Secret:argocd/argocd-secret` on every sync.
2. **ESO** — the `argocd-oidc-secret` ExternalSecret targets `argocd-secret` with `creationPolicy: Merge` and no `template.metadata`, so it copies its *own* metadata onto the shared secret. That ExternalSecret is itself tracked by ArgoCD, so it carries `argocd.argoproj.io/tracking-id: argocd:external-secrets.io/ExternalSecret:argocd/argocd-oidc-secret`, and ESO writes that value onto `argocd-secret`, clobbering ArgoCD's.

`managedFields` confirms manager `externalsecrets.external-secrets.io/argocd-oidc-secret` owns `f:metadata.f:annotations.f:argocd.argoproj.io/tracking-id` on the live secret.

Result: sync -> ArgoCD sets the correct tracking-id -> ESO overwrites it within `refreshInterval: 1h` -> drift again. `selfHeal` can't win and this annotation isn't in `ignoreDifferences`.

## Fix

- **`resources/argocd-oidc-externalsecret.yaml`** — define `spec.target.template.metadata: {}` so ESO no longer inherits the ExternalSecret's labels/annotations onto `argocd-secret`. This removes the source of the drift.
- **`app-config.yaml`** — also add `/metadata/annotations/argocd.argoproj.io~1tracking-id` to the app's `ignoreDifferences` as a guard against the transient window between an ESO refresh and the next sync. ArgoCD still tracks the secret via the `app.kubernetes.io/instance` label.

## Verification

- `kubectl kustomize cluster/apps/core/argocd` renders cleanly with the new `target.template` block.
- `task lint:yaml` — no new findings (pre-existing `#gitleaks:allow` line warnings only).

https://claude.ai/code/session_016qjFSFQWUR89DVipBCqp8Z